### PR TITLE
pass around locks for file operations and use rollup chunk names

### DIFF
--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/file/BlueReadLock.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/file/BlueReadLock.java
@@ -1,9 +1,12 @@
 package io.bluedb.disk.file;
 
-public class BlueReadLock<T> {
+import java.io.Closeable;
+
+public class BlueReadLock<T> implements Closeable {
 
 	private final LockManager<T> lockManager;
 	private final T key;
+	private boolean released = false;
 
 	public BlueReadLock(LockManager<T> lockManager, T key) {
 		this.lockManager = lockManager;
@@ -15,6 +18,14 @@ public class BlueReadLock<T> {
 	}
 
 	public void release() {
-		lockManager.releaseReadLock(key);
+		if (!released) {
+			lockManager.releaseReadLock(key);
+		}
+		released = true;
+	}
+
+	@Override
+	public void close() {
+		release();
 	}
 }

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/file/BlueWriteLock.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/file/BlueWriteLock.java
@@ -1,9 +1,12 @@
 package io.bluedb.disk.file;
 
-public class BlueWriteLock<T> {
+import java.io.Closeable;
+
+public class BlueWriteLock<T> implements Closeable {
 
 	private final LockManager<T> lockManager;
 	private final T key;
+	private boolean released = false;
 
 	public BlueWriteLock(LockManager<T> lockManager, T key) {
 		this.lockManager = lockManager;
@@ -15,6 +18,14 @@ public class BlueWriteLock<T> {
 	}
 
 	public void release() {
-		lockManager.releaseWriteLock(key);
+		if (!released) {
+			lockManager.releaseWriteLock(key);
+		}
+		released = true;
+	}
+
+	@Override
+	public void close() {
+		release();
 	}
 }

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/recovery/PendingChange.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/recovery/PendingChange.java
@@ -49,11 +49,11 @@ public class PendingChange<T extends Serializable> implements Serializable {
 	public void applyChange(Segment<T> segment) throws BlueDbException {
 		if (isInsert()) {
 			// TODO check for already existing?  probably not, probably do that in the calling function
-			segment.put(key, newValue);
+			segment.save(key, newValue);
 		} else if (isDelete()) {
 			segment.delete(key);
 		} else if (isUpdate()) {
-			segment.put(key, newValue);
+			segment.save(key, newValue);
 		}
 	}
 

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/file/FileManagerTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/file/FileManagerTest.java
@@ -104,6 +104,40 @@ public class FileManagerTest  extends TestCase {
 	}
 
 	@Test
+	public void test_createTempFilePath() {
+		Path withParent = Paths.get("grandparent", "parent", "target");
+		Path tempWithParent = FileManager.createTempFilePath(withParent);
+		Path expectedTempWithParent = Paths.get("grandparent", "parent", "_tmp_target");
+		assertEquals(expectedTempWithParent, tempWithParent);
+
+		Path withoutParent = Paths.get("target");
+		Path tempWithoutParent = FileManager.createTempFilePath(withoutParent);
+		Path expectedTempWithoutParent = Paths.get("_tmp_target");
+		assertEquals(expectedTempWithoutParent, tempWithoutParent);
+	}
+
+	@Test
+	public void test_moveFile() {
+		Path targetFilePath = Paths.get(this.getClass().getSimpleName() + ".test_junk");
+		Path tempFilePath = FileManager.createTempFilePath(targetFilePath);
+		try {
+			FileManager.ensureDirectoryExists(tempFilePath.toFile());
+			tempFilePath.toFile().createNewFile();
+			assertTrue(tempFilePath.toFile().exists());
+			assertFalse(targetFilePath.toFile().exists());
+			fileManager.lockMoveFileUnlock(tempFilePath, targetFilePath);
+			assertFalse(tempFilePath.toFile().exists());
+			assertTrue(targetFilePath.toFile().exists());
+		} catch (IOException | BlueDbException e) {
+			e.printStackTrace();
+			fail();
+		}
+		
+		recursiveDelete(targetFilePath.toFile());
+		recursiveDelete(tempFilePath.toFile());
+	}
+	
+	@Test
 	public void test_multithreaded() {
 		TestValue value = new TestValue("joe", 0);
 		File file = createFileAndWriteTestValue("testMultithreaded", value);

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/segment/SegmentTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/segment/SegmentTest.java
@@ -41,15 +41,15 @@ public class SegmentTest extends TestCase {
 		TestValue value3 = createValue("Chuck");
 		try {
 			assertFalse(segment.contains(key1At1));
-			segment.put(key1At1, value1);
+			segment.save(key1At1, value1);
 			assertTrue(segment.contains(key1At1));
 			assertFalse(segment.contains(key2At1));
 			assertFalse(segment.contains(key3At3));
-			segment.put(key2At1, value2);
+			segment.save(key2At1, value2);
 			assertTrue(segment.contains(key1At1));
 			assertTrue(segment.contains(key2At1));
 			assertFalse(segment.contains(key3At3));
-			segment.put(key3At3, value3);
+			segment.save(key3At3, value3);
 			assertTrue(segment.contains(key1At1));
 			assertTrue(segment.contains(key2At1));
 			assertTrue(segment.contains(key3At3));
@@ -78,7 +78,7 @@ public class SegmentTest extends TestCase {
 			assertEquals(null, segment.get(key2At1));
 			assertEquals(null, segment.get(key3At3));
 
-			segment.put(key1At1, value1);
+			segment.save(key1At1, value1);
 			assertTrue(segment.contains(key1At1));
 			assertFalse(segment.contains(key2At1));
 			assertFalse(segment.contains(key3At3));
@@ -86,7 +86,7 @@ public class SegmentTest extends TestCase {
 			assertEquals(null, segment.get(key2At1));
 			assertEquals(null, segment.get(key3At3));
 
-			segment.put(key2At1, value2);
+			segment.save(key2At1, value2);
 			assertTrue(segment.contains(key1At1));
 			assertTrue(segment.contains(key2At1));
 			assertFalse(segment.contains(key3At3));
@@ -94,7 +94,7 @@ public class SegmentTest extends TestCase {
 			assertEquals(value2, segment.get(key2At1));
 			assertEquals(null, segment.get(key3At3));
 
-			segment.put(key3At3, value3);
+			segment.save(key3At3, value3);
 			assertTrue(segment.contains(key1At1));
 			assertTrue(segment.contains(key2At1));
 			assertTrue(segment.contains(key3At3));
@@ -119,9 +119,9 @@ public class SegmentTest extends TestCase {
 		TestValue value2 = createValue("Bob");
 		TestValue value3 = createValue("Chuck");
 		try {
-			segment.put(key1At1, value1);
-			segment.put(key2At1, value2);
-			segment.put(key3At3, value3);
+			segment.save(key1At1, value1);
+			segment.save(key2At1, value2);
+			segment.save(key3At3, value3);
 			assertTrue(segment.contains(key1At1));
 			assertTrue(segment.contains(key2At1));
 			assertTrue(segment.contains(key3At3));
@@ -171,17 +171,17 @@ public class SegmentTest extends TestCase {
 			assertEquals(null, segment.get(key2At1));
 			assertEquals(null, segment.get(key3At3));
 
-			segment.put(key3At3, value3);
+			segment.save(key3At3, value3);
 			assertEquals(null, segment.get(key1At1));
 			assertEquals(null, segment.get(key2At1));
 			assertEquals(value3, segment.get(key3At3));
 
-			segment.put(key2At1, value2);
+			segment.save(key2At1, value2);
 			assertEquals(null, segment.get(key1At1));
 			assertEquals(value2, segment.get(key2At1));
 			assertEquals(value3, segment.get(key3At3));
 
-			segment.put(key1At1, value1);
+			segment.save(key1At1, value1);
 			assertEquals(value1, segment.get(key1At1));
 			assertEquals(value2, segment.get(key2At1));
 			assertEquals(value3, segment.get(key3At3));
@@ -202,9 +202,9 @@ public class SegmentTest extends TestCase {
 		TestValue value2 = createValue("Bob");
 		TestValue value3 = createValue("Chuck");
 		try {
-			segment.put(key1At1, value1);
-			segment.put(key2At1, value2);
-			segment.put(key3At3, value3);
+			segment.save(key1At1, value1);
+			segment.save(key2At1, value2);
+			segment.save(key3At3, value3);
 			List<BlueEntity<TestValue>> entities0to0 = segment.getRange(0,0);
 			List<TestValue> values0to0 = extractValues(entities0to0);
 			assertEquals(0, values0to0.size());
@@ -247,18 +247,18 @@ public class SegmentTest extends TestCase {
 			values = segment.getAll();
 			assertEquals(0, values.size());
 
-			segment.put(key1At1, value1);
+			segment.save(key1At1, value1);
 			values = segment.getAll();
 			assertEquals(1, values.size());
 			assertTrue(values.contains(value1));
 
-			segment.put(key2At1, value2);
+			segment.save(key2At1, value2);
 			values = segment.getAll();
 			assertEquals(2, values.size());
 			assertTrue(values.contains(value1));
 			assertTrue(values.contains(value2));
 
-			segment.put(key3At3, value3);
+			segment.save(key3At3, value3);
 			values = segment.getAll();
 			assertEquals(3, values.size());
 			assertTrue(values.contains(value1));


### PR DESCRIPTION
To understand this merge request, first look at Segment.getReadLockFor(Path).

This function enables us to find (and lock) the appropriate file.  This is necessary because the files might shift around while it's deciding which file to read.  So it must not settle on which file to read until it has a lock.

To avoid deadlock and keep code understandable, I also made locks Closeable and changed file operation functions to require locks to be passed in.