### PR TITLE
Cleanup in different thread

### DIFF
--- a/BlueDB/src/main/java/io/bluedb/api/BlueDb.java
+++ b/BlueDB/src/main/java/io/bluedb/api/BlueDb.java
@@ -7,7 +7,7 @@ import io.bluedb.api.keys.BlueKey;
 
 public interface BlueDb {
 	
-	public <T extends Serializable> BlueCollection<T> initializeCollection(String name, Class<? extends BlueKey> keyType, Class<T> valueType, Class<? extends Serializable>... additionalClassesToRegister) throws BlueDbException;
+	public <T extends Serializable> BlueCollection<T> initializeCollection(String name, Class<? extends BlueKey> keyType, Class<T> valueType, @SuppressWarnings("unchecked") Class<? extends Serializable>... additionalClassesToRegister) throws BlueDbException;
 
 	public <T extends Serializable> BlueCollection<T> getCollection(String name, Class<T> valueType) throws BlueDbException;
 

--- a/BlueDB/src/main/java/io/bluedb/api/BlueQuery.java
+++ b/BlueDB/src/main/java/io/bluedb/api/BlueQuery.java
@@ -8,6 +8,8 @@ public interface BlueQuery<T extends Serializable> {
 
 	BlueQuery<T> where(Condition<T> c);
 
+	BlueQuery<T> byStartTime();
+
 	BlueQuery<T> beforeTime(long time);
 	BlueQuery<T> beforeOrAtTime(long time);
 
@@ -20,5 +22,4 @@ public interface BlueQuery<T extends Serializable> {
 	void delete() throws BlueDbException;
 	void update(Updater<T> updater) throws BlueDbException;
 	public int count() throws BlueDbException;
-
 }

--- a/BlueDBInMemory/src/main/java/io/bluedb/memory/BlueQueryImpl.java
+++ b/BlueDBInMemory/src/main/java/io/bluedb/memory/BlueQueryImpl.java
@@ -54,6 +54,12 @@ class BlueQueryImpl<T extends Serializable> implements BlueQuery<T> {
 	}
 
 	@Override
+	public BlueQuery<T> byStartTime() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
 	public List<T> getList() throws BlueDbException {
 		return collection.getList(minTime, maxTime, objectConditions);
 	}

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/BlueDbOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/BlueDbOnDisk.java
@@ -45,7 +45,7 @@ public class BlueDbOnDisk implements BlueDb {
 	}
 
 	@Override
-	public <T extends Serializable> BlueCollection<T> initializeCollection(String name, Class<? extends BlueKey> keyType, Class<T> valueType, Class<? extends Serializable>... additionalClassesToRegister) throws BlueDbException {
+	public <T extends Serializable> BlueCollection<T> initializeCollection(String name, Class<? extends BlueKey> keyType, Class<T> valueType, @SuppressWarnings("unchecked") Class<? extends Serializable>... additionalClassesToRegister) throws BlueDbException {
 		synchronized (collections) {
 			@SuppressWarnings("unchecked")
 			BlueCollectionOnDisk<T> collection = (BlueCollectionOnDisk<T>) collections.get(name);

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/Blutils.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/Blutils.java
@@ -58,6 +58,18 @@ public class Blutils {
 		return results;
 	}
 
+	public static <X, Y> List<Y> mapIgnoringExceptions(List<? extends X> values, CheckedFunction<? super X, ? extends Y> mapper) {
+		List<Y> results = new ArrayList<>();
+		for (X originalValue: values) {
+			try {
+				Y newValue = mapper.apply(originalValue);
+				results.add(newValue);
+			} catch (Throwable e) {
+			}
+		}
+		return results;
+	}
+
 	public static <X> List<X> filter(List<X> values, Predicate<X> condition) {
 		List<X> results = new ArrayList<>();
 		for (X value: values) {

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/Blutils.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/Blutils.java
@@ -98,4 +98,27 @@ public class Blutils {
 			file.delete();
 		}
 	}
+
+	@FunctionalInterface
+	public interface UnreliableFunction<T, E extends Throwable> {
+	   T get() throws E;
+	}
+	
+
+	public static <T, E extends Throwable> T tryMultipleTimes(int attempts, UnreliableFunction<T, E> function) throws Throwable {
+		if (attempts <= 0) {
+			throw new IllegalArgumentException("Number of attempts must be > 0.");
+		}
+		int failures = 0;
+		Throwable lastThrowable = null;
+		while (failures < attempts) {
+			try {
+				return function.get();
+			} catch (Throwable t) {
+				failures++;
+				lastThrowable = t;
+			}
+		}
+		throw lastThrowable;
+	}
 }

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/Blutils.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/Blutils.java
@@ -117,6 +117,7 @@ public class Blutils {
 			} catch (Throwable t) {
 				failures++;
 				lastThrowable = t;
+				trySleep(1);
 			}
 		}
 		throw lastThrowable;

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/backup/BackupManager.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/backup/BackupManager.java
@@ -58,7 +58,7 @@ public class BackupManager {
 	}
 
 	private void copyDataFolders(BlueCollectionOnDisk<?> collection, Path tempFolder) throws BlueDbException {
-		for (Segment<?> segment: collection.getSegmentManager().getExistingSegments(Long.MIN_VALUE, Long.MAX_VALUE)) {
+		for (Segment<?> segment: collection.getSegmentManager().getAllExistingSegments()) {
 			copyDataFolders(segment, tempFolder);
 		}
 	}

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
@@ -172,6 +172,7 @@ public class BlueCollectionOnDisk<T extends Serializable> implements BlueCollect
 	}
 
 	public void shutdown() {
+		recoveryManager.getChangeHistoryCleaner().stop();
 		rollupScheduler.forceScheduleRollups();
 		rollupScheduler.stop();
 		executor.shutdown();

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
@@ -84,10 +84,6 @@ public class BlueCollectionOnDisk<T extends Serializable> implements BlueCollect
 	@Override
 	public void insert(BlueKey key, T value) throws BlueDbException {
 		ensureCorrectKeyType(key);
-		// TODO roll up to a smaller time range?
-		// TODO report insert when the insert task actually runs?
-		Range timeRange = segmentManager.getSegmentRange(key.getGroupingNumber());
-		rollupScheduler.reportInsert(timeRange);
 		Runnable insertTask = new InsertTask<T>(this, key, value);
 		executeTask(insertTask);
 	}
@@ -149,6 +145,10 @@ public class BlueCollectionOnDisk<T extends Serializable> implements BlueCollect
 
 	public SegmentManager<T> getSegmentManager() {
 		return segmentManager;
+	}
+
+	public RollupScheduler getRollupScheduler() {
+		return rollupScheduler;
 	}
 
 	public RecoveryManager<T> getRecoveryManager() {

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
@@ -172,8 +172,9 @@ public class BlueCollectionOnDisk<T extends Serializable> implements BlueCollect
 	}
 
 	public void shutdown() {
+		rollupScheduler.forceScheduleRollups();
 		rollupScheduler.stop();
-		executor.shutdownNow();
+		executor.shutdown();
 	}
 
 	public Class<T> getType() {

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
@@ -109,9 +109,9 @@ public class BlueCollectionOnDisk<T extends Serializable> implements BlueCollect
 		return lastEntity == null ? null : lastEntity.getKey();
 	}
 
-	public List<BlueEntity<T>> findMatches(Range range, List<Condition<T>> conditions) throws BlueDbException {
+	public List<BlueEntity<T>> findMatches(Range range, List<Condition<T>> conditions, boolean byStartTime) throws BlueDbException {
 		List<BlueEntity<T>> results = new ArrayList<>();
-		try (CollectionEntityIterator<T> iterator = new CollectionEntityIterator<T>(this, range)) {
+		try (CollectionEntityIterator<T> iterator = new CollectionEntityIterator<T>(this, range, byStartTime)) {
 			while (iterator.hasNext()) {
 				BlueEntity<T> entity = iterator.next();
 				T value = entity.getValue();

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/BlueCollectionOnDisk.java
@@ -47,7 +47,7 @@ public class BlueCollectionOnDisk<T extends Serializable> implements BlueCollect
 	private final RollupScheduler rollupScheduler;
 	private final CollectionMetaData metaData;
 
-	public BlueCollectionOnDisk(BlueDbOnDisk db, String name, Class<? extends BlueKey> requestedKeyType, Class<T> valueType, Class<? extends Serializable>... additionalRegisteredClasses) throws BlueDbException {
+	public BlueCollectionOnDisk(BlueDbOnDisk db, String name, Class<? extends BlueKey> requestedKeyType, Class<T> valueType, @SuppressWarnings("unchecked") Class<? extends Serializable>... additionalRegisteredClasses) throws BlueDbException {
 		this.valueType = valueType;
 		collectionPath = Paths.get(db.getPath().toString(), name);
 		collectionPath.toFile().mkdirs();
@@ -109,9 +109,9 @@ public class BlueCollectionOnDisk<T extends Serializable> implements BlueCollect
 		return lastEntity == null ? null : lastEntity.getKey();
 	}
 
-	public List<BlueEntity<T>> findMatches(long min, long max, List<Condition<T>> conditions) throws BlueDbException {
+	public List<BlueEntity<T>> findMatches(Range range, List<Condition<T>> conditions) throws BlueDbException {
 		List<BlueEntity<T>> results = new ArrayList<>();
-		try (CollectionEntityIterator<T> iterator = new CollectionEntityIterator<T>(this, min, max)) {
+		try (CollectionEntityIterator<T> iterator = new CollectionEntityIterator<T>(this, range)) {
 			while (iterator.hasNext()) {
 				BlueEntity<T> entity = iterator.next();
 				T value = entity.getValue();

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/CollectionEntityIterator.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/CollectionEntityIterator.java
@@ -6,23 +6,22 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import io.bluedb.disk.segment.SegmentEntityIterator;
+import io.bluedb.disk.segment.Range;
 import io.bluedb.disk.segment.Segment;
 import io.bluedb.disk.serialization.BlueEntity;
 
 public class CollectionEntityIterator<T extends Serializable> implements Iterator<BlueEntity<T>>, Closeable {
 
 	final private List<Segment<T>> segments;
-	final private long min;
-	final private long max;
+	final private Range range;
 	private long endGroupingValueOfCompletedSegments;
 	private SegmentEntityIterator<T> segmentIterator;
 	private BlueEntity<T> next;
 
-	public CollectionEntityIterator(final BlueCollectionOnDisk<T> collection, final long min, final long max) {
-		this.min = min;
-		this.max = max;
+	public CollectionEntityIterator(final BlueCollectionOnDisk<T> collection, Range range) {
+		this.range = range;
 		this.endGroupingValueOfCompletedSegments = Long.MIN_VALUE;
-		segments = collection.getSegmentManager().getExistingSegments(min, max);
+		segments = collection.getSegmentManager().getExistingSegments(range);
 		Collections.sort(segments);
 	}
 
@@ -74,6 +73,6 @@ public class CollectionEntityIterator<T extends Serializable> implements Iterato
 			endGroupingValueOfCompletedSegments = endOfLastSegment;
 		}
 		Segment<T> segment = segments.remove(0);
-		return segment.getIterator(endGroupingValueOfCompletedSegments, min, max);
+		return segment.getIterator(endGroupingValueOfCompletedSegments, range);
 	}
 }

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/CollectionEntityIterator.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/CollectionEntityIterator.java
@@ -18,9 +18,9 @@ public class CollectionEntityIterator<T extends Serializable> implements Iterato
 	private SegmentEntityIterator<T> segmentIterator;
 	private BlueEntity<T> next;
 
-	public CollectionEntityIterator(final BlueCollectionOnDisk<T> collection, Range range) {
+	public CollectionEntityIterator(final BlueCollectionOnDisk<T> collection, Range range, boolean byStartTime) {
 		this.range = range;
-		this.endGroupingValueOfCompletedSegments = Long.MIN_VALUE;
+		this.endGroupingValueOfCompletedSegments = byStartTime ? (range.getStart()) - 1 : Long.MIN_VALUE;
 		segments = collection.getSegmentManager().getExistingSegments(range);
 		Collections.sort(segments);
 	}

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/CollectionValueIterator.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/CollectionValueIterator.java
@@ -12,13 +12,13 @@ public class CollectionValueIterator<T extends Serializable> implements Closeabl
 	private CollectionEntityIterator<T> entityIterator;
 	private AutoCloseCountdown timeoutCloser;
 	
-	public CollectionValueIterator(BlueCollectionOnDisk<T> collection, Range range) {
-		entityIterator = new CollectionEntityIterator<T>(collection, range);
+	public CollectionValueIterator(BlueCollectionOnDisk<T> collection, Range range, boolean byStartTime) {
+		entityIterator = new CollectionEntityIterator<T>(collection, range, byStartTime);
 		timeoutCloser = new AutoCloseCountdown(this, TIMEOUT_DEFAULT_MILLIS);
 	}
 
-	public CollectionValueIterator(BlueCollectionOnDisk<T> collection, Range range, long timeout) {
-		entityIterator = new CollectionEntityIterator<T>(collection, range);
+	public CollectionValueIterator(BlueCollectionOnDisk<T> collection, Range range, long timeout, boolean byStartTime) {
+		entityIterator = new CollectionEntityIterator<T>(collection, range, byStartTime);
 		timeoutCloser = new AutoCloseCountdown(this, timeout);
 	}
 

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/CollectionValueIterator.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/CollectionValueIterator.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 import io.bluedb.api.CloseableIterator;
 import io.bluedb.disk.lock.AutoCloseCountdown;
+import io.bluedb.disk.segment.Range;
 
 public class CollectionValueIterator<T extends Serializable> implements CloseableIterator<T> {
 
@@ -11,13 +12,13 @@ public class CollectionValueIterator<T extends Serializable> implements Closeabl
 	private CollectionEntityIterator<T> entityIterator;
 	private AutoCloseCountdown timeoutCloser;
 	
-	public CollectionValueIterator(BlueCollectionOnDisk<T> collection, long min, long max) {
-		entityIterator = new CollectionEntityIterator<T>(collection, min, max);
+	public CollectionValueIterator(BlueCollectionOnDisk<T> collection, Range range) {
+		entityIterator = new CollectionEntityIterator<T>(collection, range);
 		timeoutCloser = new AutoCloseCountdown(this, TIMEOUT_DEFAULT_MILLIS);
 	}
 
-	public CollectionValueIterator(BlueCollectionOnDisk<T> collection, long min, long max, long timeout) {
-		entityIterator = new CollectionEntityIterator<T>(collection, min, max);
+	public CollectionValueIterator(BlueCollectionOnDisk<T> collection, Range range, long timeout) {
+		entityIterator = new CollectionEntityIterator<T>(collection, range);
 		timeoutCloser = new AutoCloseCountdown(this, timeout);
 	}
 

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/LastEntityFinder.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/LastEntityFinder.java
@@ -12,7 +12,7 @@ public class LastEntityFinder<T extends Serializable> {
 	final private List<Segment<T>> segments;
 
 	public LastEntityFinder(final BlueCollectionOnDisk<T> collection) {
-		segments = collection.getSegmentManager().getExistingSegments(Long.MIN_VALUE, Long.MAX_VALUE);
+		segments = collection.getSegmentManager().getAllExistingSegments();
 		Collections.sort(segments);
 		Collections.reverse(segments);
 	}

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/task/DeleteMultipleTask.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/task/DeleteMultipleTask.java
@@ -17,19 +17,21 @@ public class DeleteMultipleTask<T extends Serializable> extends QueryTask {
 	private final long minGroupingValue;
 	private final long maxGroupingValue;
 	private final List<Condition<T>> conditions;
+	private final boolean byStartTime;
 	
-	public DeleteMultipleTask(BlueCollectionOnDisk<T> collection, long min, long max, List<Condition<T>> conditions) {
+	public DeleteMultipleTask(BlueCollectionOnDisk<T> collection, long min, long max, List<Condition<T>> conditions, boolean byStartTime) {
 		this.collection = collection;
 		this.minGroupingValue = min;
 		this.maxGroupingValue = max;
 		this.conditions = conditions;
+		this.byStartTime = byStartTime;
 	}
 
 	@Override
 	public void execute() throws BlueDbException {
 		RecoveryManager<T> recoveryManager = collection.getRecoveryManager();
 		Range range = new Range(minGroupingValue, maxGroupingValue);
-		List<BlueEntity<T>> entities = collection.findMatches(range, conditions);
+		List<BlueEntity<T>> entities = collection.findMatches(range, conditions, byStartTime);
 		List<PendingChange<T>> changes = createDeletePendingChanges(entities);
 		for (PendingChange<T> change: changes) {
 			recoveryManager.saveChange(change);

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/task/DeleteMultipleTask.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/task/DeleteMultipleTask.java
@@ -9,6 +9,7 @@ import io.bluedb.api.keys.BlueKey;
 import io.bluedb.disk.collection.BlueCollectionOnDisk;
 import io.bluedb.disk.recovery.PendingChange;
 import io.bluedb.disk.recovery.RecoveryManager;
+import io.bluedb.disk.segment.Range;
 import io.bluedb.disk.serialization.BlueEntity;
 
 public class DeleteMultipleTask<T extends Serializable> extends QueryTask {
@@ -27,7 +28,8 @@ public class DeleteMultipleTask<T extends Serializable> extends QueryTask {
 	@Override
 	public void execute() throws BlueDbException {
 		RecoveryManager<T> recoveryManager = collection.getRecoveryManager();
-		List<BlueEntity<T>> entities = collection.findMatches(minGroupingValue, maxGroupingValue, conditions);
+		Range range = new Range(minGroupingValue, maxGroupingValue);
+		List<BlueEntity<T>> entities = collection.findMatches(range, conditions);
 		List<PendingChange<T>> changes = createDeletePendingChanges(entities);
 		for (PendingChange<T> change: changes) {
 			recoveryManager.saveChange(change);

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/task/UpdateMultipleTask.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/task/UpdateMultipleTask.java
@@ -10,6 +10,7 @@ import io.bluedb.api.exceptions.BlueDbException;
 import io.bluedb.disk.collection.BlueCollectionOnDisk;
 import io.bluedb.disk.recovery.PendingChange;
 import io.bluedb.disk.recovery.RecoveryManager;
+import io.bluedb.disk.segment.Range;
 import io.bluedb.disk.serialization.BlueEntity;
 import io.bluedb.disk.serialization.BlueSerializer;
 
@@ -31,7 +32,8 @@ public class UpdateMultipleTask<T extends Serializable> extends QueryTask {
 
 	@Override
 	public void execute() throws BlueDbException {
-		List<BlueEntity<T>> entities = collection.findMatches(min, max, conditions);
+		Range range = new Range(min, max);
+		List<BlueEntity<T>> entities = collection.findMatches(range, conditions);
 		List<PendingChange<T>> updates;
 		try {
 			updates = createUpdates(entities, updater);

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/task/UpdateMultipleTask.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/collection/task/UpdateMultipleTask.java
@@ -20,20 +20,22 @@ public class UpdateMultipleTask<T extends Serializable> extends QueryTask {
 	private final long min;
 	private final long max;
 	private final  List<Condition<T>> conditions;
+	private final boolean byStartTime;
 
 
-	public UpdateMultipleTask(BlueCollectionOnDisk<T> collection, long min, long max, List<Condition<T>> conditions, Updater<T> updater) {
+	public UpdateMultipleTask(BlueCollectionOnDisk<T> collection, long min, long max, List<Condition<T>> conditions, Updater<T> updater, boolean byStartTime) {
 		this.collection = collection;
 		this.min = min;
 		this.max = max;
 		this.conditions = conditions;
 		this.updater = updater;
+		this.byStartTime = byStartTime;
 	}
 
 	@Override
 	public void execute() throws BlueDbException {
 		Range range = new Range(min, max);
-		List<BlueEntity<T>> entities = collection.findMatches(range, conditions);
+		List<BlueEntity<T>> entities = collection.findMatches(range, conditions, byStartTime);
 		List<PendingChange<T>> updates;
 		try {
 			updates = createUpdates(entities, updater);

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/file/FileManager.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/file/FileManager.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.bluedb.api.exceptions.BlueDbException;
+import io.bluedb.disk.Blutils;
 import io.bluedb.disk.lock.BlueReadLock;
 import io.bluedb.disk.lock.BlueWriteLock;
 import io.bluedb.disk.lock.LockManager;
@@ -150,8 +151,8 @@ public class FileManager {
 	public static void moveFile(Path src, BlueWriteLock<Path> lock) throws BlueDbException {
 		Path dst = lock.getKey();
 		try {
-			Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE);
-		} catch (IOException e) {
+			Blutils.tryMultipleTimes(3, () -> Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE));
+		} catch (Throwable e) {
 			e.printStackTrace();
 			throw new BlueDbException("trouble moving file from "  + src.toString() + " to " + dst.toString() , e);
 		}
@@ -160,8 +161,8 @@ public class FileManager {
 	public static void moveWithoutLock(Path src, Path dst) throws BlueDbException {
 		try {
 			ensureDirectoryExists(dst.toFile());
-			Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE);
-		} catch (IOException e) {
+			Blutils.tryMultipleTimes(3, () -> Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE));
+		} catch (Throwable e) {
 			e.printStackTrace();
 			throw new BlueDbException("trouble moving file from "  + src.toString() + " to " + dst.toString() , e);
 		}

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/file/FileManager.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/file/FileManager.java
@@ -151,7 +151,7 @@ public class FileManager {
 	public static void moveFile(Path src, BlueWriteLock<Path> lock) throws BlueDbException {
 		Path dst = lock.getKey();
 		try {
-			Blutils.tryMultipleTimes(3, () -> Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE));
+			Blutils.tryMultipleTimes(5, () -> Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE));
 		} catch (Throwable e) {
 			e.printStackTrace();
 			throw new BlueDbException("trouble moving file from "  + src.toString() + " to " + dst.toString() , e);
@@ -161,7 +161,7 @@ public class FileManager {
 	public static void moveWithoutLock(Path src, Path dst) throws BlueDbException {
 		try {
 			ensureDirectoryExists(dst.toFile());
-			Blutils.tryMultipleTimes(3, () -> Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE));
+			Blutils.tryMultipleTimes(5, () -> Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE));
 		} catch (Throwable e) {
 			e.printStackTrace();
 			throw new BlueDbException("trouble moving file from "  + src.toString() + " to " + dst.toString() , e);

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/query/BlueQueryOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/query/BlueQueryOnDisk.java
@@ -13,13 +13,14 @@ import io.bluedb.disk.collection.BlueCollectionOnDisk;
 import io.bluedb.disk.collection.CollectionValueIterator;
 import io.bluedb.disk.collection.task.DeleteMultipleTask;
 import io.bluedb.disk.collection.task.UpdateMultipleTask;
+import io.bluedb.disk.segment.Range;
 
 public class BlueQueryOnDisk<T extends Serializable> implements BlueQuery<T> {
 
 	private BlueCollectionOnDisk<T> collection;
 	private List<Condition<T>> objectConditions = new LinkedList<>();
-	private long maxTime = Long.MAX_VALUE;
-	private long minTime = Long.MIN_VALUE;
+	private long max = Long.MAX_VALUE;
+	private long min = Long.MIN_VALUE;
 
 	public BlueQueryOnDisk(BlueCollectionOnDisk<T> collection) {
 		this.collection = collection;
@@ -35,31 +36,32 @@ public class BlueQueryOnDisk<T extends Serializable> implements BlueQuery<T> {
 
 	@Override
 	public BlueQuery<T> afterTime(long time) {
-		minTime = Math.max(minTime, Math.max(time + 1,time)); // last part to avoid overflow errors
+		min = Math.max(min, Math.max(time + 1,time)); // last part to avoid overflow errors
 		return this;
 	}
 
 	@Override
 	public BlueQuery<T> afterOrAtTime(long time) {
-		minTime = Math.max(minTime, time);
+		min = Math.max(min, time);
 		return this;
 	}
 
 	@Override
 	public BlueQuery<T> beforeTime(long time) {
-		maxTime = Math.min(maxTime, Math.min(time - 1,time)); // last part to avoid overflow errors
+		max = Math.min(max, Math.min(time - 1,time)); // last part to avoid overflow errors
 		return this;
 	}
 
 	@Override
 	public BlueQuery<T> beforeOrAtTime(long time) {
-		maxTime = Math.min(maxTime, time);
+		max = Math.min(max, time);
 		return this;
 	}
 
 	@Override
 	public List<T> getList() throws BlueDbException {
-		return collection.findMatches(minTime, maxTime, objectConditions)
+		Range range = new Range(min, max);
+		return collection.findMatches(range, objectConditions)
 				.stream()
 				.map((e) -> e.getValue())
 				.collect(Collectors.toList());
@@ -67,18 +69,19 @@ public class BlueQueryOnDisk<T extends Serializable> implements BlueQuery<T> {
 
 	@Override
 	public CloseableIterator<T> getIterator() throws BlueDbException {
-		return new CollectionValueIterator<T>(collection, minTime, maxTime);
+		Range range = new Range(min, max);
+		return new CollectionValueIterator<T>(collection, range);
 	}
 
 	@Override
 	public void delete() throws BlueDbException {
-		Runnable deleteAllTask = new DeleteMultipleTask<T>(collection, minTime, maxTime, objectConditions);
+		Runnable deleteAllTask = new DeleteMultipleTask<T>(collection, min, max, objectConditions);
 		collection.executeTask(deleteAllTask);
 	}
 
 	@Override
 	public void update(Updater<T> updater) throws BlueDbException {
-		Runnable updateMultipleTask = new UpdateMultipleTask<T>(collection, minTime, maxTime, objectConditions, updater);
+		Runnable updateMultipleTask = new UpdateMultipleTask<T>(collection, min, max, objectConditions, updater);
 		collection.executeTask(updateMultipleTask);
 	}
 

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/recovery/ChangeHistoryCleaner.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/recovery/ChangeHistoryCleaner.java
@@ -13,6 +13,7 @@ public class ChangeHistoryCleaner implements Runnable {
 	private int completedChangeLimit = DEFAULT_RETENTION_LIMIT;
 	private final AtomicInteger holdsOnHistoryCleanup = new AtomicInteger(0);
 	private long waitBetweenCleanups = 500;
+	private boolean isStopped = false;
 	final Path historyFolderPath;
 	RecoveryManager<?> recoveryManager;
 	Thread thread;
@@ -58,12 +59,12 @@ public class ChangeHistoryCleaner implements Runnable {
 	}
 
 	public void stop() {
-		thread.stop();
+		isStopped = true;
 	}
 
 	@Override
 	public void run() {
-		while(true) {
+		while(!isStopped) {
 			cleanupHistory();
 			Blutils.trySleep(waitBetweenCleanups);
 		}

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/recovery/ChangeHistoryCleaner.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/recovery/ChangeHistoryCleaner.java
@@ -1,0 +1,72 @@
+package io.bluedb.disk.recovery;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import io.bluedb.disk.Blutils;
+
+public class ChangeHistoryCleaner implements Runnable {
+
+	private static int DEFAULT_RETENTION_LIMIT = 200;
+	private int completedChangeLimit = DEFAULT_RETENTION_LIMIT;
+	private final AtomicInteger holdsOnHistoryCleanup = new AtomicInteger(0);
+	private long waitBetweenCleanups = 500;
+	final Path historyFolderPath;
+	RecoveryManager<?> recoveryManager;
+	Thread thread;
+
+	public ChangeHistoryCleaner(RecoveryManager<?> recoveryManager) {
+		this.recoveryManager = recoveryManager;
+		this.historyFolderPath = recoveryManager.getHistoryFolder();
+		thread = new Thread(this);
+		thread.start();
+	}
+
+	public void setRetentionLimit(int completedChangeLimit) {
+		this.completedChangeLimit = completedChangeLimit;
+	}
+
+	public void placeHoldOnHistoryCleanup() {
+		holdsOnHistoryCleanup.incrementAndGet();
+	}
+
+	public void removeHoldOnHistoryCleanup() {
+		holdsOnHistoryCleanup.decrementAndGet();
+	}
+
+	public List<TimeStampedFile> getCompletedTimeStampedFiles() {
+		List<File> historicChangeFiles = recoveryManager.getCompletedChangeFiles();
+		List<TimeStampedFile> timestampedFiles = Blutils.mapIgnoringExceptions(historicChangeFiles, (f) -> new TimeStampedFile(f) );
+		return timestampedFiles;
+	}
+
+	public void cleanupHistory() {
+		if (holdsOnHistoryCleanup.get() > 0) {
+			return;
+		}
+		List<TimeStampedFile> timestampedFiles = getCompletedTimeStampedFiles();
+		Collections.sort(timestampedFiles);
+		int numFilesToDelete = Math.max(0, timestampedFiles.size() - completedChangeLimit);
+		List<TimeStampedFile> filesToDelete = timestampedFiles.subList(0, numFilesToDelete);
+		filesToDelete.forEach((f) -> f.getFile().delete());
+	}
+
+	public void setWaitBetweenCleanups(long millis) {
+		this.waitBetweenCleanups = millis;
+	}
+
+	public void stop() {
+		thread.stop();
+	}
+
+	@Override
+	public void run() {
+		while(true) {
+			cleanupHistory();
+			Blutils.trySleep(waitBetweenCleanups);
+		}
+		
+	}
+}

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/Segment.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/Segment.java
@@ -103,6 +103,10 @@ public class Segment <T extends Serializable> implements Comparable<Segment<T>> 
 		return segmentRange;
 	}
 
+	public SegmentEntityIterator<T> getIterator(long highestGroupingNumberCompleted, Range range) {
+		return new SegmentEntityIterator<>(this, highestGroupingNumberCompleted, range.getStart(), range.getEnd());
+	}
+
 	public SegmentEntityIterator<T> getIterator(long highestGroupingNumberCompleted, long rangeMin, long rangeMax) {
 		return new SegmentEntityIterator<>(this, highestGroupingNumberCompleted, rangeMin, rangeMax);
 	}

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/Segment.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/Segment.java
@@ -88,6 +88,8 @@ public class Segment <T extends Serializable> implements Comparable<Segment<T>> 
 		try (BlueWriteLock<Path> targetFileLock = lockManager.acquireWriteLock(targetPath)) {
 			FileManager.moveFile(tmpPath, targetFileLock);
 		}
+		// TODO roll up to a smaller time range?
+		collection.getRollupScheduler().reportInsert(segmentRange);
 	}
 
 	public T get(BlueKey key) throws BlueDbException {

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/SegmentManager.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/SegmentManager.java
@@ -46,8 +46,13 @@ public class SegmentManager<T extends Serializable> {
 				.collect(Collectors.toList());
 	}
 
-	public List<Segment<T>> getExistingSegments(long minValue, long maxValue) {
-		return pathManager.getExistingSegmentFiles(minValue, maxValue).stream()
+	public List<Segment<T>> getAllExistingSegments() {
+		Range allValues = new Range(Long.MIN_VALUE, Long.MAX_VALUE);
+		return getExistingSegments(allValues);
+	}
+
+	public List<Segment<T>> getExistingSegments(Range range) {
+		return pathManager.getExistingSegmentFiles(range).stream()
 				.map((f) -> (toSegment(f.toPath())))
 				.sorted()
 				.collect(Collectors.toList());

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/path/SegmentPathManager.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/path/SegmentPathManager.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import io.bluedb.api.keys.BlueKey;
 import io.bluedb.disk.Blutils;
 import io.bluedb.disk.file.FileManager;
+import io.bluedb.disk.segment.Range;
 
 
 public interface SegmentPathManager {
@@ -43,6 +44,10 @@ public interface SegmentPathManager {
 			i += segmentSize;
 		}
 		return paths;
+	}
+
+	public default List<File> getExistingSegmentFiles(Range range) {
+		return getExistingSegmentFiles(range.getStart(), range.getEnd());
 	}
 
 	public default List<File> getExistingSegmentFiles(long minValue, long maxValue) {

--- a/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/rollup/RollupScheduler.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/disk/segment/rollup/RollupScheduler.java
@@ -72,6 +72,13 @@ public class RollupScheduler implements Runnable {
 		}
 	}
 
+	public void forceScheduleRollups() {
+		List<Range> allRangesWaitingForRollups = new ArrayList<>(lastInsertTimes.keySet());
+		for (Range timeRange: allRangesWaitingForRollups) {
+			scheduleRollup(timeRange);
+		}
+	}
+
 	public void setWaitBetweenReviews(long newWaitTimeMillis) {
 		waitBetweenReviews = newWaitTimeMillis;
 	}

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/BlutilsTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/BlutilsTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import io.bluedb.api.Condition;
+import io.bluedb.api.exceptions.BlueDbException;
 import io.bluedb.disk.Blutils.UnreliableFunction;
 
 public class BlutilsTest {
@@ -66,6 +67,19 @@ public class BlutilsTest {
 		List<Long> expectedResults = Arrays.asList(7L, 5L, 1000L);
 		List<Long> mappedValues = Blutils.map(originalValues, (s) -> Long.valueOf(s));
 		assertEquals(expectedResults, mappedValues);
+	}
+
+	@Test
+	public void test_mapIgnoringExceptions() {
+		List<String> originalValues = Arrays.asList("7", "5", "1000", "garbage");
+		List<Long> expectedResults = Arrays.asList(7L, 5L, 1000L);
+		List<Long> mappedValues = Blutils.mapIgnoringExceptions(originalValues, (s) -> Long.valueOf(s));
+		assertEquals(expectedResults, mappedValues);
+		try {
+			Blutils.map(originalValues, (s) -> Long.valueOf(s));
+			fail();
+		} catch (Throwable e) {
+		}
 	}
 
 	@Test

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/BlueCollectionOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/BlueCollectionOnDiskTest.java
@@ -171,12 +171,12 @@ public class BlueCollectionOnDiskTest extends BlueDbDiskTestBase {
 		List<BlueEntity<TestValue>> allEntities, entitiesWithJoe, entities3to5, entities2to3, entities0to1, entities0to0;
 
 		Condition<TestValue> isJoe = (v) -> v.getName().equals("Joe");
-		allEntities = getTimeCollection().findMatches(new Range(0, 3), new ArrayList<>());
-		entitiesWithJoe = getTimeCollection().findMatches(new Range(0, 5), Arrays.asList(isJoe));
-		entities3to5 = getTimeCollection().findMatches(new Range(3, 5), new ArrayList<>());
-		entities2to3 = getTimeCollection().findMatches(new Range(2, 3), new ArrayList<>());
-		entities0to1 = getTimeCollection().findMatches(new Range(0, 1), new ArrayList<>());
-		entities0to0 = getTimeCollection().findMatches(new Range(0, 0), new ArrayList<>());
+		allEntities = getTimeCollection().findMatches(new Range(0, 3), new ArrayList<>(), false);
+		entitiesWithJoe = getTimeCollection().findMatches(new Range(0, 5), Arrays.asList(isJoe), false);
+		entities3to5 = getTimeCollection().findMatches(new Range(3, 5), new ArrayList<>(), false);
+		entities2to3 = getTimeCollection().findMatches(new Range(2, 3), new ArrayList<>(), false);
+		entities0to1 = getTimeCollection().findMatches(new Range(0, 1), new ArrayList<>(), false);
+		entities0to0 = getTimeCollection().findMatches(new Range(0, 0), new ArrayList<>(), false);
 
 		assertEquals(2, allEntities.size());
 		assertEquals(1, entitiesWithJoe.size());
@@ -187,6 +187,42 @@ public class BlueCollectionOnDiskTest extends BlueDbDiskTestBase {
 		assertEquals(1, entities0to1.size());
 		assertEquals(valueJoe, entities0to1.get(0).getValue());
 		assertEquals(0, entities0to0.size());
+	}
+
+	@Test
+	public void test_findMatches_byStartTime() throws Exception {
+		TestValue valueJoe = new TestValue("Joe");
+		TestValue valueBob = new TestValue("Bob");
+		insertAtTimeFrame(1, 2, valueJoe);
+		insertAtTimeFrame(2, 3, valueBob);
+		List<BlueEntity<TestValue>> allEntities, entities3to5, entities2to3, entities0to1, entities0to0;
+
+		allEntities = getTimeCollection().findMatches(new Range(0, 3), new ArrayList<>(), true);
+		entities3to5 = getTimeCollection().findMatches(new Range(3, 5), new ArrayList<>(), true);
+		entities2to3 = getTimeCollection().findMatches(new Range(2, 3), new ArrayList<>(), true);
+		entities0to1 = getTimeCollection().findMatches(new Range(0, 1), new ArrayList<>(), true);
+		entities0to0 = getTimeCollection().findMatches(new Range(0, 0), new ArrayList<>(), true);
+
+		assertEquals(2, allEntities.size());
+		assertEquals(0, entities3to5.size());
+		assertEquals(1, entities2to3.size());
+		assertEquals(valueBob, entities2to3.get(0).getValue());
+		assertEquals(1, entities0to1.size());
+		assertEquals(valueJoe, entities0to1.get(0).getValue());
+		assertEquals(0, entities0to0.size());
+	}
+
+	@Test
+	public void test_count_byStartTime() throws Exception {
+		TestValue valueJoe = new TestValue("Joe");
+		TestValue valueBob = new TestValue("Bob");
+		insertAtTimeFrame(1, 2, valueJoe);
+		insertAtTimeFrame(2, 3, valueBob);
+
+		assertEquals(2, getTimeCollection().query().byStartTime().afterOrAtTime(1).beforeOrAtTime(3).count());
+		assertEquals(2, getTimeCollection().query().byStartTime().afterOrAtTime(1).beforeOrAtTime(2).count());
+		assertEquals(1, getTimeCollection().query().byStartTime().afterOrAtTime(2).beforeOrAtTime(3).count());
+		assertEquals(0, getTimeCollection().query().byStartTime().afterOrAtTime(3).beforeOrAtTime(4).count());
 	}
 
 	@Test

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/BlueCollectionOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/BlueCollectionOnDiskTest.java
@@ -171,12 +171,12 @@ public class BlueCollectionOnDiskTest extends BlueDbDiskTestBase {
 		List<BlueEntity<TestValue>> allEntities, entitiesWithJoe, entities3to5, entities2to3, entities0to1, entities0to0;
 
 		Condition<TestValue> isJoe = (v) -> v.getName().equals("Joe");
-		allEntities = getTimeCollection().findMatches(0, 3, new ArrayList<>());
-		entitiesWithJoe = getTimeCollection().findMatches(0, 5, Arrays.asList(isJoe));
-		entities3to5 = getTimeCollection().findMatches(3, 5, new ArrayList<>());
-		entities2to3 = getTimeCollection().findMatches(2, 3, new ArrayList<>());
-		entities0to1 = getTimeCollection().findMatches(0, 1, new ArrayList<>());
-		entities0to0 = getTimeCollection().findMatches(0, 0, new ArrayList<>());
+		allEntities = getTimeCollection().findMatches(new Range(0, 3), new ArrayList<>());
+		entitiesWithJoe = getTimeCollection().findMatches(new Range(0, 5), Arrays.asList(isJoe));
+		entities3to5 = getTimeCollection().findMatches(new Range(3, 5), new ArrayList<>());
+		entities2to3 = getTimeCollection().findMatches(new Range(2, 3), new ArrayList<>());
+		entities0to1 = getTimeCollection().findMatches(new Range(0, 1), new ArrayList<>());
+		entities0to0 = getTimeCollection().findMatches(new Range(0, 0), new ArrayList<>());
 
 		assertEquals(2, allEntities.size());
 		assertEquals(1, entitiesWithJoe.size());

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/CollectionEntityIteratorTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/CollectionEntityIteratorTest.java
@@ -25,7 +25,7 @@ public class CollectionEntityIteratorTest extends BlueDbDiskTestBase {
         Path chunkPath = Paths.get(segment.getPath().toString(), range.toUnderscoreDelimitedString());
 
         getTimeCollection().insert(key, value);
-        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(1, 2));
+        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(1, 2), false);
         assertFalse(getLockManager().isLocked(chunkPath));
         iterator.hasNext();  // force it to open the next file
         assertTrue(getLockManager().isLocked(chunkPath));
@@ -42,18 +42,18 @@ public class CollectionEntityIteratorTest extends BlueDbDiskTestBase {
 
         getTimeCollection().insert(key1, value1);
         getTimeCollection().insert(key2, value2);
-        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 0));
+        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 0), false);
         assertFalse(iterator.hasNext());
         iterator.close();
 
-        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(1, 1));
+        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(1, 1), false);
         assertTrue(iterator.hasNext());
         assertTrue(iterator.hasNext()); // make sure doing it twice doesn't break anything
         iterator.next();
         assertFalse(iterator.hasNext());
         iterator.close();
 
-        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(1, 2));
+        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(1, 2), false);
         assertTrue(iterator.hasNext());
         assertEquals(value1, iterator.next().getValue());
         assertTrue(iterator.hasNext());
@@ -72,18 +72,18 @@ public class CollectionEntityIteratorTest extends BlueDbDiskTestBase {
         getTimeCollection().insert(key1, value1);
         getTimeCollection().insert(key2, value2);
 
-        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 0));
+        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 0), false);
         List<BlueEntity<TestValue>> iteratorContents = toList(iterator);
         iterator.close();
         assertEquals(0, iteratorContents.size());
 
-        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 1));
+        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 1), false);
         iteratorContents = toList(iterator);
         iterator.close();
         assertEquals(1, iteratorContents.size());
 
 
-        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 2));
+        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 2), false);
         iteratorContents = new ArrayList<>();
         iteratorContents.add(iterator.next());
         iteratorContents.add(iterator.next());  // make sure next work right after a next
@@ -113,7 +113,7 @@ public class CollectionEntityIteratorTest extends BlueDbDiskTestBase {
 		List<TestValue> valuesFromFirstSegment = toValueList(firstSegmentIterator);
 		SegmentEntityIterator<TestValue> secondSegmentIterator = secondSegment.getIterator(0, segmentSize * 2 - 1);
 		List<TestValue> valuesFromSecondSegment = toValueList(secondSegmentIterator);
-		CollectionEntityIterator<TestValue> collectionIterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, segmentSize * 2 - 1));
+		CollectionEntityIterator<TestValue> collectionIterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, segmentSize * 2 - 1), false);
 		List<TestValue> valuesFromEitherSegment = toValueList(collectionIterator);
 
 		assertEquals(valuesExpectedInFirstSegment, valuesFromFirstSegment);

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/CollectionEntityIteratorTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/CollectionEntityIteratorTest.java
@@ -25,7 +25,7 @@ public class CollectionEntityIteratorTest extends BlueDbDiskTestBase {
         Path chunkPath = Paths.get(segment.getPath().toString(), range.toUnderscoreDelimitedString());
 
         getTimeCollection().insert(key, value);
-        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), 1, 2);
+        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(1, 2));
         assertFalse(getLockManager().isLocked(chunkPath));
         iterator.hasNext();  // force it to open the next file
         assertTrue(getLockManager().isLocked(chunkPath));
@@ -42,18 +42,18 @@ public class CollectionEntityIteratorTest extends BlueDbDiskTestBase {
 
         getTimeCollection().insert(key1, value1);
         getTimeCollection().insert(key2, value2);
-        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), 0, 0);
+        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 0));
         assertFalse(iterator.hasNext());
         iterator.close();
 
-        iterator = new CollectionEntityIterator<>(getTimeCollection(), 1, 1);
+        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(1, 1));
         assertTrue(iterator.hasNext());
         assertTrue(iterator.hasNext()); // make sure doing it twice doesn't break anything
         iterator.next();
         assertFalse(iterator.hasNext());
         iterator.close();
 
-        iterator = new CollectionEntityIterator<>(getTimeCollection(), 1, 2);
+        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(1, 2));
         assertTrue(iterator.hasNext());
         assertEquals(value1, iterator.next().getValue());
         assertTrue(iterator.hasNext());
@@ -72,18 +72,18 @@ public class CollectionEntityIteratorTest extends BlueDbDiskTestBase {
         getTimeCollection().insert(key1, value1);
         getTimeCollection().insert(key2, value2);
 
-        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), 0, 0);
+        CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 0));
         List<BlueEntity<TestValue>> iteratorContents = toList(iterator);
         iterator.close();
         assertEquals(0, iteratorContents.size());
 
-        iterator = new CollectionEntityIterator<>(getTimeCollection(), 0, 1);
+        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 1));
         iteratorContents = toList(iterator);
         iterator.close();
         assertEquals(1, iteratorContents.size());
 
 
-        iterator = new CollectionEntityIterator<>(getTimeCollection(), 0, 2);
+        iterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, 2));
         iteratorContents = new ArrayList<>();
         iteratorContents.add(iterator.next());
         iteratorContents.add(iterator.next());  // make sure next work right after a next
@@ -113,7 +113,7 @@ public class CollectionEntityIteratorTest extends BlueDbDiskTestBase {
 		List<TestValue> valuesFromFirstSegment = toValueList(firstSegmentIterator);
 		SegmentEntityIterator<TestValue> secondSegmentIterator = secondSegment.getIterator(0, segmentSize * 2 - 1);
 		List<TestValue> valuesFromSecondSegment = toValueList(secondSegmentIterator);
-		CollectionEntityIterator<TestValue> collectionIterator = new CollectionEntityIterator<>(getTimeCollection(), 0, segmentSize * 2 - 1);
+		CollectionEntityIterator<TestValue> collectionIterator = new CollectionEntityIterator<>(getTimeCollection(), new Range(0, segmentSize * 2 - 1));
 		List<TestValue> valuesFromEitherSegment = toValueList(collectionIterator);
 
 		assertEquals(valuesExpectedInFirstSegment, valuesFromFirstSegment);

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/CollectionValueIteratorTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/CollectionValueIteratorTest.java
@@ -114,7 +114,7 @@ public class CollectionValueIteratorTest extends BlueDbDiskTestBase {
         getTimeCollection().insert(key3at3, value3);
 
 		// validate that the iterator is working normally
-		try (CollectionValueIterator<TestValue> iterator =  new CollectionValueIterator<>(getTimeCollection(), 0, 3)) {
+		try (CollectionValueIterator<TestValue> iterator =  new CollectionValueIterator<>(getTimeCollection(), new Range(0, 3))) {
 			iteratorContents = toList(iterator);
 			iterator.close();
 			assertEquals(3, iteratorContents.size());
@@ -125,7 +125,7 @@ public class CollectionValueIteratorTest extends BlueDbDiskTestBase {
 		String fileName = Range.forValueAndRangeSize(1, 1).toUnderscoreDelimitedString();
 		Path firstFilePath = Paths.get(segmentPath.toString(), fileName);
 
-		try (CollectionValueIterator<TestValue> iterator =  new CollectionValueIterator<>(getTimeCollection(), 0, 3, 20)) {
+		try (CollectionValueIterator<TestValue> iterator =  new CollectionValueIterator<>(getTimeCollection(), new Range(0, 3), 20)) {
 			TestValue first = iterator.next(); // make sure that the underlying resources are acquired
 			assertEquals(value1, first);
 

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/CollectionValueIteratorTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/CollectionValueIteratorTest.java
@@ -114,7 +114,7 @@ public class CollectionValueIteratorTest extends BlueDbDiskTestBase {
         getTimeCollection().insert(key3at3, value3);
 
 		// validate that the iterator is working normally
-		try (CollectionValueIterator<TestValue> iterator =  new CollectionValueIterator<>(getTimeCollection(), new Range(0, 3))) {
+		try (CollectionValueIterator<TestValue> iterator =  new CollectionValueIterator<>(getTimeCollection(), new Range(0, 3), false)) {
 			iteratorContents = toList(iterator);
 			iterator.close();
 			assertEquals(3, iteratorContents.size());
@@ -125,7 +125,7 @@ public class CollectionValueIteratorTest extends BlueDbDiskTestBase {
 		String fileName = Range.forValueAndRangeSize(1, 1).toUnderscoreDelimitedString();
 		Path firstFilePath = Paths.get(segmentPath.toString(), fileName);
 
-		try (CollectionValueIterator<TestValue> iterator =  new CollectionValueIterator<>(getTimeCollection(), new Range(0, 3), 20)) {
+		try (CollectionValueIterator<TestValue> iterator =  new CollectionValueIterator<>(getTimeCollection(), new Range(0, 3), 20, false)) {
 			TestValue first = iterator.next(); // make sure that the underlying resources are acquired
 			assertEquals(value1, first);
 

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/TaskTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/collection/TaskTest.java
@@ -22,7 +22,7 @@ public class TaskTest extends TestCase {
 		long max = 101;
 		ArrayList<Condition<?>> conditions = new ArrayList<>();
 		@SuppressWarnings({"rawtypes", "unchecked"})
-		Runnable task = new DeleteMultipleTask(null, min, max, conditions);
+		Runnable task = new DeleteMultipleTask(null, min, max, conditions, false);
 		String taskString = task.toString();
 		assertTrue(taskString.contains(task.getClass().getSimpleName()));
 		assertTrue(taskString.contains(String.valueOf(min)));
@@ -45,7 +45,7 @@ public class TaskTest extends TestCase {
 		long max = 101;
 		ArrayList<Condition<?>> conditions = new ArrayList<>();
 		@SuppressWarnings({"rawtypes", "unchecked"})
-		Runnable task = new UpdateMultipleTask(null, min, max, conditions, null);
+		Runnable task = new UpdateMultipleTask(null, min, max, conditions, null, false);
 		String taskString = task.toString();
 		assertTrue(taskString.contains(task.getClass().getSimpleName()));
 		assertTrue(taskString.contains(String.valueOf(min)));

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/recovery/ChangeHistoryCleanerTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/recovery/ChangeHistoryCleanerTest.java
@@ -1,0 +1,65 @@
+package io.bluedb.disk.recovery;
+
+import java.io.File;
+import java.util.List;
+import org.junit.Test;
+import io.bluedb.disk.BlueDbDiskTestBase;
+import io.bluedb.disk.TestValue;
+
+public class ChangeHistoryCleanerTest extends BlueDbDiskTestBase {
+
+	@Test
+	public void test_cleanupHistory() throws Exception {
+		long thirtyMinutesAgo = System.currentTimeMillis() - 30 * 60 * 1000;
+		long sixtyMinutesAgo = System.currentTimeMillis() - 60 * 60 * 1000;
+		long ninetyMinutesAgo = System.currentTimeMillis() - 90 * 60 * 1000;
+		long oneHundredMinutesAgo = System.currentTimeMillis() - 100 * 60 * 1000;
+		Recoverable<TestValue> changePending = createRecoverable(thirtyMinutesAgo);
+		Recoverable<TestValue> change30 = createRecoverable(thirtyMinutesAgo);
+		Recoverable<TestValue> change60 = createRecoverable(sixtyMinutesAgo);
+		Recoverable<TestValue> change90 = createRecoverable(ninetyMinutesAgo);
+		Recoverable<TestValue> change100 = createRecoverable(oneHundredMinutesAgo);
+		assertEquals(thirtyMinutesAgo, change30.getTimeCreated());
+		assertEquals(sixtyMinutesAgo, change60.getTimeCreated());
+		assertEquals(ninetyMinutesAgo, change90.getTimeCreated());
+		assertEquals(oneHundredMinutesAgo, change100.getTimeCreated());
+		getRecoveryManager().getChangeHistoryCleaner().setWaitBetweenCleanups(100_000);  // to prevent automatic cleanup
+//		getRecoveryManager().cleanupHistory(); // to reset timer and prevent automatic cleanup
+		List<File> changesBeforeInsert = getRecoveryManager().getChangeHistory(Long.MIN_VALUE, Long.MAX_VALUE);
+		getRecoveryManager().saveChange(changePending);
+		getRecoveryManager().saveChange(change30);
+		getRecoveryManager().saveChange(change60);
+		getRecoveryManager().saveChange(change90);
+		getRecoveryManager().saveChange(change100);
+		getRecoveryManager().markComplete(change30);
+		getRecoveryManager().markComplete(change60);
+		getRecoveryManager().markComplete(change90);
+		getRecoveryManager().markComplete(change100);
+		List<File> changesBeforeCleanup = getRecoveryManager().getChangeHistory(Long.MIN_VALUE, Long.MAX_VALUE);
+
+		getRecoveryManager().placeHoldOnHistoryCleanup();
+		getRecoveryManager().getChangeHistoryCleaner().setRetentionLimit(2);
+
+		getRecoveryManager().getChangeHistoryCleaner().cleanupHistory();
+		List<File> changesAfterCleanupDuringHold = getRecoveryManager().getChangeHistory(Long.MIN_VALUE, Long.MAX_VALUE);
+		getRecoveryManager().removeHoldOnHistoryCleanup();
+
+		getRecoveryManager().getChangeHistoryCleaner().cleanupHistory();
+		List<File> changesAfterCleanup2 = getRecoveryManager().getChangeHistory(Long.MIN_VALUE, Long.MAX_VALUE);
+
+		getRecoveryManager().getChangeHistoryCleaner().setRetentionLimit(0);
+		getRecoveryManager().getChangeHistoryCleaner().cleanupHistory();
+		List<File> changesAfterCleanup0 = getRecoveryManager().getChangeHistory(Long.MIN_VALUE, Long.MAX_VALUE);
+
+//		assertFalse(getRecoveryManager().isTimeForHistoryCleanup());  // since we already just did cleanup
+		assertEquals(0, changesBeforeInsert.size());
+		assertEquals(5, changesBeforeCleanup.size());
+		assertEquals(5, changesAfterCleanupDuringHold.size());
+		assertEquals(3, changesAfterCleanup2.size());  // two completed stay, plus the pending
+		assertEquals(1, changesAfterCleanup0.size());  // everything goes except pending
+	}
+
+	private Recoverable<TestValue> createRecoverable(long time){
+		return new TestRecoverable(time);
+	}
+}

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/segment/SegmentEntityIteratorTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/segment/SegmentEntityIteratorTest.java
@@ -270,7 +270,7 @@ public class SegmentEntityIteratorTest extends BlueDbDiskTestBase {
 			stringCollection.insert(key, value);
 		}
 		
-		List<Segment<String>> segments = stringCollection.getSegmentManager().getExistingSegments(Long.MIN_VALUE, Long.MAX_VALUE);
+		List<Segment<String>> segments = stringCollection.getSegmentManager().getExistingSegments(new Range(Long.MIN_VALUE, Long.MAX_VALUE));
 		assertEquals(n, segments.size());
 
 		for (Segment<String> segment: segments) {

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/segment/SegmentManagerTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/segment/SegmentManagerTest.java
@@ -42,14 +42,14 @@ public class SegmentManagerTest extends BlueDbDiskTestBase {
 		BlueKey timeFrameKey = new TimeFrameKey(1, minTime, maxTime);  // should barely span 3 segments
 		TestValue value = new TestValue("Bob", 0);
 		try {
-			List<Segment<TestValue>> existingSegments = getSegmentManager().getExistingSegments(minTime, maxTime);
+			List<Segment<TestValue>> existingSegments = getSegmentManager().getExistingSegments(new Range(minTime, maxTime));
 			assertEquals(0, existingSegments.size());
 			getTimeCollection().insert(timeFrameKey, value);
-			existingSegments = getSegmentManager().getExistingSegments(minTime, maxTime);
+			existingSegments = getSegmentManager().getExistingSegments(new Range(minTime, maxTime));
 			assertEquals(3, existingSegments.size());
-			List<Segment<TestValue>> existingSegments0to0 = getSegmentManager().getExistingSegments(minTime, minTime);
+			List<Segment<TestValue>> existingSegments0to0 = getSegmentManager().getExistingSegments(new Range(minTime, minTime));
 			assertEquals(1, existingSegments0to0.size());
-			List<Segment<TestValue>> existingSegmentsOutsideRange = getSegmentManager().getExistingSegments(maxTime * 2, maxTime * 2);
+			List<Segment<TestValue>> existingSegmentsOutsideRange = getSegmentManager().getExistingSegments(new Range(maxTime * 2, maxTime * 2));
 			assertEquals(0, existingSegmentsOutsideRange.size());
 		} catch (BlueDbException e) {
 			e.printStackTrace();

--- a/BlueDBOnDisk/src/test/java/io/bluedb/disk/segment/rollup/RollupSchedulerTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/disk/segment/rollup/RollupSchedulerTest.java
@@ -70,6 +70,26 @@ public class RollupSchedulerTest extends BlueDbDiskTestBase {
 	}
 
 	@Test
+	public void test_forceScheduleRollups() throws Exception {
+		List<Range> rollupsRequested = new ArrayList<>();
+		BlueCollectionOnDisk<TestValue> mockCollection = createMockCollection(rollupsRequested);
+		RollupScheduler mockRollupScheduler = new RollupScheduler(mockCollection);
+		Range timeRange = new Range(0, 1);
+		assertEquals(Long.MIN_VALUE, mockRollupScheduler.getLastInsertTime(timeRange));
+
+		long now = System.currentTimeMillis();
+		mockRollupScheduler.reportInsert(timeRange, now);
+		assertEquals(now, mockRollupScheduler.getLastInsertTime(timeRange));
+
+		mockRollupScheduler.scheduleReadyRollups();
+		assertEquals(0, rollupsRequested.size());
+
+		mockRollupScheduler.forceScheduleRollups();
+		assertEquals(1, rollupsRequested.size());
+		assertTrue(rollupsRequested.contains(timeRange));
+	}
+
+	@Test
 	public void test_run() throws Exception {
 		List<Range> rollupsRequested = new ArrayList<>();
 		BlueCollectionOnDisk<TestValue> mockCollection = createMockCollection(rollupsRequested);


### PR DESCRIPTION
Previously, cleanup of the change history was done in the same thread as writes, causing writes to occasionally block.

This should make writes faster and more consistent.