### PR TITLE
This gets rid of the one-thread-per-collection issue

### DIFF
--- a/BlueDBOnDisk/src/main/java/io/bluedb/util/CachedSingleThreadingPool.java
+++ b/BlueDBOnDisk/src/main/java/io/bluedb/util/CachedSingleThreadingPool.java
@@ -1,0 +1,75 @@
+package io.bluedb.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class CachedSingleThreadingPool {
+
+	
+	private ConcurrentHashMap<String, ConcurrentLinkedQueue<FutureTask<Void>>> collectionTaskMap = new ConcurrentHashMap<>();
+	private ExecutorService cachedThreadPool = Executors.newCachedThreadPool();
+	
+	public Future<?> submit(String collectionName, Runnable runnable) {
+		
+		synchronized (collectionTaskMap) {
+			FutureTask<Void> future = new FutureTask<>(runnable, null);
+			
+			ConcurrentLinkedQueue<FutureTask<Void>> collectionTaskQueue = collectionTaskMap.get(collectionName);
+			if (collectionTaskQueue == null) {
+				collectionTaskQueue = new ConcurrentLinkedQueue<>();
+				collectionTaskMap.put(collectionName, collectionTaskQueue);
+				collectionTaskQueue.add(future);
+				pollAndSubmit(collectionName);		
+			}
+			else {
+				collectionTaskQueue.add(future);
+			}
+				
+			
+			return future;
+		}
+	}
+	
+	
+
+	protected void pollAndSubmit(String collectionName) {
+		synchronized (collectionTaskMap) {
+			ConcurrentLinkedQueue<FutureTask<Void>> collectionTaskQueue = collectionTaskMap.get(collectionName);
+			if (collectionTaskQueue == null || collectionTaskQueue.isEmpty()) {
+				collectionTaskMap.remove(collectionName);
+				return;
+			}
+			
+			FutureTask<Void> task = collectionTaskQueue.poll();
+			cachedThreadPool.submit(runPollSubmit(task, collectionName));
+		}
+		
+	}
+	
+	
+	private Runnable runPollSubmit(FutureTask<Void> futureTask, String collection) {
+		return new Runnable() {
+			@Override
+			public void run() {
+				futureTask.run();
+				
+				
+				pollAndSubmit(collection);
+			}
+		};
+	}
+	
+	public int getActiveCount() {
+		return ((ThreadPoolExecutor)cachedThreadPool).getActiveCount();
+	}
+	
+	public int getLargestPoolSize() {
+		return ((ThreadPoolExecutor)cachedThreadPool).getLargestPoolSize();
+	}
+
+}

--- a/BlueDBOnDisk/src/test/java/io/bluedb/util/CachedSingleThreadingPoolTest.java
+++ b/BlueDBOnDisk/src/test/java/io/bluedb/util/CachedSingleThreadingPoolTest.java
@@ -1,0 +1,81 @@
+package io.bluedb.util;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+
+public class CachedSingleThreadingPoolTest {
+
+	@Test
+	public void testSubmit() throws InterruptedException, ExecutionException {
+		CachedSingleThreadingPool pool = new CachedSingleThreadingPool();
+		final StringBuilder angle = new StringBuilder();
+		final StringBuilder breads = new StringBuilder();
+		final StringBuilder cat = new StringBuilder();
+		final StringBuilder dog = new StringBuilder();
+		
+		pool.submit("A", () -> appendAfterSleep(angle, "a", 50)); pool.submit("C", () -> appendAfterSleep(cat, "a", 50));  
+		pool.submit("A", () -> appendAfterSleep(angle, "n", 40)); 
+		pool.submit("A", () -> appendAfterSleep(angle, "g", 30)); 
+		pool.submit("A", () -> appendAfterSleep(angle, "l", 20)); pool.submit("ZZZ", () -> appendAfterSleep(cat, "c", 0));
+		pool.submit("A", () -> appendAfterSleep(angle, "e", 10)); 
+		Future<?> angleTest = pool.submit("A", () -> assertEquals("angle", angle.toString())); 
+		
+		int activeCount = pool.getActiveCount();
+		int largestPoolSize = pool.getLargestPoolSize();
+		assertTrue("There should be <= 3 active threads - actual: " + activeCount, activeCount <= 3);
+		assertTrue("There should be <= 3 max threads - actual: " + largestPoolSize, largestPoolSize <= 3);
+		
+		
+		pool.submit("B", () -> appendAfterSleep(breads, "b", 50)); //this should use the ZZZ thread
+		pool.submit("B", () -> appendAfterSleep(breads, "r", 0)); pool.submit("C", () -> appendAfterSleep(cat, "t", 0));
+		pool.submit("B", () -> appendAfterSleep(breads, "e", 40));
+		pool.submit("B", () -> appendAfterSleep(breads, "a", 30));
+		pool.submit("B", () -> appendAfterSleep(breads, "d", 20)); Future<?> catTest = pool.submit("C", () -> assertEquals("cat", cat.toString()));
+		pool.submit("B", () -> appendAfterSleep(breads, "s", 10));
+		Future<?> breadsTest = pool.submit("B", () -> assertEquals("breads", breads.toString()));
+		
+		activeCount = pool.getActiveCount();
+		largestPoolSize = pool.getLargestPoolSize();
+		assertTrue("There should be <= 3 active threads - actual: " + activeCount, activeCount <= 3);
+		assertTrue("There should be <= 4 max threads - actual: " + largestPoolSize, largestPoolSize <= 4);
+		
+		angleTest.get();
+		Thread.sleep(1);
+		
+		pool.submit("D", () -> dog.append("d")); //should use A thread
+		pool.submit("D", () -> dog.append("o"));
+		pool.submit("D", () -> dog.append("g"));
+		Future<?> dogTest = pool.submit("D", () -> assertEquals("dog", dog.toString()));
+		
+		activeCount = pool.getActiveCount();
+		largestPoolSize = pool.getLargestPoolSize();
+		assertTrue("There should be <= 3 active threads - actual: " + activeCount, activeCount <= 3);
+		assertTrue("There should be <= 5 max threads - actual: " + largestPoolSize, largestPoolSize <= 5);
+		
+		angleTest.get();
+		breadsTest.get();
+		catTest.get();
+		dogTest.get();
+		
+		
+		activeCount = pool.getActiveCount();
+		assertTrue("There should be 0 active threads - actual: " + activeCount, activeCount == 0);
+		
+	}
+	
+	private void appendAfterSleep(StringBuilder sb, String stringToAppend, long timeout) {
+		try {
+			if (timeout > 0)
+				Thread.sleep(timeout);
+			sb.append(stringToAppend);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+		
+	}
+
+}


### PR DESCRIPTION
It replaces it with a cached thread pool that makes sure tasks are all
executed in order.

I removed an executor.shutdown() call
at io.bluedb.disk.collection.BlueCollectionOnDisk.shutdown(BlueCollectionOnDisk.java:186).
Because cached thread pools clean themselves up this will not be an
issue unless you were relying on that shutdown to prevent future task
submissions, in which case you'll need to make CachedSingleThreadingPool
handle shutdowns.

The included test verifies that it is working as expected, but may
benefit from more scrutiny.