### PR TITLE
Serialization checks

### DIFF
--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/task/InsertTask.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/task/InsertTask.java
@@ -28,7 +28,13 @@ public class InsertTask<T extends Serializable> extends QueryTask {
 		if (collection.contains(key)) {
 			throw new DuplicateKeyException("key already exists", key);
 		}
-		PendingChange<T> change = PendingChange.createInsert(key, value, serializer);
+		PendingChange<T> change;
+		try {
+			change = PendingChange.createInsert(key, value, serializer);
+		} catch(Throwable t) {
+			throw new BlueDbException("Error inserting value", t);
+		}
+		
 		recoveryManager.saveChange(change);
 		change.apply(collection);
 		recoveryManager.markComplete(change);

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/task/ReplaceTask.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/task/ReplaceTask.java
@@ -34,7 +34,6 @@ public class ReplaceTask<T extends Serializable> extends QueryTask {
 		try {
 			change = PendingChange.createUpdate(key, value, mapper, serializer);
 		} catch(Throwable t) {
-			t.printStackTrace();
 			throw new BlueDbException("Error updating value", t);
 		}
 		recoveryManager.saveChange(change);

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/task/UpdateTask.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/task/UpdateTask.java
@@ -33,7 +33,6 @@ public class UpdateTask<T extends Serializable> extends QueryTask {
 		try {
 			change = PendingChange.createUpdate(key, value, updater, serializer);
 		} catch(Throwable t) {
-			t.printStackTrace();
 			throw new BlueDbException("Error updating value", t);
 		}
 		recoveryManager.saveChange(change);

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/PendingChange.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/PendingChange.java
@@ -12,6 +12,7 @@ import org.bluedb.disk.collection.index.IndexManager;
 import org.bluedb.disk.segment.Segment;
 import org.bluedb.disk.serialization.BlueEntity;
 import org.bluedb.disk.serialization.BlueSerializer;
+import org.bluedb.disk.serialization.validation.SerializationException;
 
 public class PendingChange<T extends Serializable> implements Serializable, Recoverable<T> {
 
@@ -34,25 +35,25 @@ public class PendingChange<T extends Serializable> implements Serializable, Reco
 		return new PendingChange<T>(key, value, null);
 	}
 
-	public static <T extends Serializable> PendingChange<T> createInsert(BlueKey key, T value, BlueSerializer serializer){
+	public static <T extends Serializable> PendingChange<T> createInsert(BlueKey key, T value, BlueSerializer serializer) throws SerializationException {
 		T newValue = serializer.clone(value);
 		return new PendingChange<T>(key, null, newValue);
 	}
 
-	public static <T extends Serializable> PendingChange<T> createUpdate(BlueKey key, T value, Updater<T> updater, BlueSerializer serializer){
+	public static <T extends Serializable> PendingChange<T> createUpdate(BlueKey key, T value, Updater<T> updater, BlueSerializer serializer) throws SerializationException {
 		T oldValue = serializer.clone(value);
 		T newValue = serializer.clone(oldValue);
 		updater.update(newValue);
 		return new PendingChange<T>(key, oldValue, newValue);
 	}
 
-	public static <T extends Serializable> PendingChange<T> createUpdate(BlueEntity<T> entity, Mapper<T> mapper, BlueSerializer serializer){
+	public static <T extends Serializable> PendingChange<T> createUpdate(BlueEntity<T> entity, Mapper<T> mapper, BlueSerializer serializer) throws SerializationException {
 		BlueKey key = entity.getKey();
 		T value = entity.getValue();
 		return createUpdate(key, value, mapper, serializer);
 	}
 
-	public static <T extends Serializable> PendingChange<T> createUpdate(BlueKey key, T value, Mapper<T> mapper, BlueSerializer serializer){
+	public static <T extends Serializable> PendingChange<T> createUpdate(BlueKey key, T value, Mapper<T> mapper, BlueSerializer serializer) throws SerializationException {
 		T oldValue = serializer.clone(value);
 		T newValue = mapper.update(serializer.clone(oldValue));
 		return new PendingChange<T>(key, oldValue, newValue);

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/segment/writer/BatchWriter.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/segment/writer/BatchWriter.java
@@ -10,6 +10,7 @@ import org.bluedb.disk.file.BlueObjectInput;
 import org.bluedb.disk.file.BlueObjectOutput;
 import org.bluedb.disk.recovery.IndividualChange;
 import org.bluedb.disk.serialization.BlueEntity;
+import org.bluedb.disk.serialization.validation.SerializationException;
 
 public class BatchWriter<T extends Serializable> implements StreamingWriter<T> {
 
@@ -23,28 +24,45 @@ public class BatchWriter<T extends Serializable> implements StreamingWriter<T> {
 		while (input.hasNext() && !changes.isEmpty()) {
 			BlueKey peekFromInput = input.peek().getKey();
 			BlueKey peekFromChanges = changes.peek().getKey();
+			
 			if (peekFromInput.equals(peekFromChanges)) {
-				input.next(); // this is the value that is being replaced or deleted so throw it out
-				pollOneChangeAndWrite(changes, output);
+				replaceItemWithNextChange(input.nextWithoutDeserializing(), changes, output);
 			} else if (peekFromInput.compareTo(peekFromChanges) > 0) {
-				pollOneChangeAndWrite(changes, output);
+				writeNextChange(changes, output);
 			} else {
-				output.write(input.next());
+				output.writeBytes(input.nextWithoutDeserializing());
 			}
 		}
+		
 		// drain out the remaining items from whichever is not empty
 		while (input.hasNext()) {
-			output.write(input.next());
+			output.writeBytes(input.nextWithoutDeserializing());
 		}
 		while (!changes.isEmpty()) {
-			pollOneChangeAndWrite(changes, output);
+			writeNextChange(changes, output);
 		}
 	}
 
-	private static <T extends Serializable> void pollOneChangeAndWrite(LinkedList<IndividualChange<T>> changes, BlueObjectOutput<BlueEntity<T>> output) throws BlueDbException {
+	private static <T extends Serializable> void writeNextChange(LinkedList<IndividualChange<T>> changes, BlueObjectOutput<BlueEntity<T>> output) throws BlueDbException {
+		replaceItemWithNextChange(null, changes, output);
+	}
+
+	private static <T extends Serializable> void replaceItemWithNextChange(byte[] originalItemBytes, LinkedList<IndividualChange<T>> changes, BlueObjectOutput<BlueEntity<T>> output) throws BlueDbException {
 		BlueEntity<T> newEntity = changes.poll().getNewEntity();
-		if (newEntity != null) {
-			output.write(newEntity);
-		} // else it's a delete anyway
+		
+		if(newEntity != null) {
+			try {
+				output.write(newEntity);
+			} catch (SerializationException e) {
+				//Don't let a single item failing to serialize stop the rest of the changes in the batch
+				
+				if(originalItemBytes != null) {
+					new BlueDbException("A BlueDB batch query was supposed to replace an object but the replacement object failed to serialize. The object will remain unchanged. Key: " + newEntity.getKey(), e).printStackTrace();
+					output.writeBytes(originalItemBytes);
+				} else {
+					new BlueDbException("A BlueDB batch query was supposed to insert an object but failed to serialize it. Key: " + newEntity.getKey(), e).printStackTrace();
+				}
+			}
+		} //else - if newItem is null then the item is effectively deleted by not writing it to the output
 	}
 }

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/BlueSerializer.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/BlueSerializer.java
@@ -10,5 +10,5 @@ public interface BlueSerializer {
 
 	public Object deserializeObjectFromByteArray(byte[] bytes) throws SerializationException;
 
-	public <T extends Serializable> T clone(T object);
+	public <T extends Serializable> T clone(T object) throws SerializationException;
 }

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/BlueSerializer.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/BlueSerializer.java
@@ -6,7 +6,7 @@ import org.bluedb.disk.serialization.validation.SerializationException;
 
 public interface BlueSerializer {
 
-	public byte[] serializeObjectToByteArray(Object o);
+	public byte[] serializeObjectToByteArray(Object o) throws SerializationException;
 
 	public Object deserializeObjectFromByteArray(byte[] bytes) throws SerializationException;
 

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/ThreadLocalFstSerializer.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/ThreadLocalFstSerializer.java
@@ -21,7 +21,7 @@ import org.nustaq.serialization.simpleapi.DefaultCoder;
 
 public class ThreadLocalFstSerializer extends ThreadLocal<DefaultCoder> implements BlueSerializer {
 	
-	private static final int MAX_DESERIALIZE_ATTEMPTS = 5;
+	private static final int MAX_ATTEMPTS = 5;
 	
 	private Class<?>[] registeredSerializableClasses;
 	
@@ -49,9 +49,51 @@ public class ThreadLocalFstSerializer extends ThreadLocal<DefaultCoder> implemen
 		);
 	}
 
-	@Override
-	public byte[] serializeObjectToByteArray(Object o) {
+	protected byte[] serializeObjectToByteArrayWithoutChecks(Object o) {
 		return get().toByteArray(o);
+	}
+
+	@Override
+	public byte[] serializeObjectToByteArray(Object o) throws SerializationException {
+		validateObjectBeforeSerializing(o);
+		return serializeValidObject(o);
+	}
+
+	protected byte[] serializeValidObject(Object o) throws SerializationException {
+		Throwable failureCause = null;
+		int retryCount = 0;
+		while(retryCount < MAX_ATTEMPTS) {
+			try {
+				byte[] serializedBytes = get().toByteArray(o);
+				validateBytesAfterSerialization(serializedBytes);
+				return serializedBytes;
+			} catch(Throwable t) {
+				failureCause = t;
+				retryCount++;
+			}
+		}
+		
+		throw new SerializationException("Failed to serialize object since it keeps producing bytes that cannot be deserialized properly", failureCause); //Don't try to put the object details in the message since any usage of the invalid field will throw an exception. The caused by will contain some good detail
+	}
+	
+	protected void validateObjectBeforeSerializing(Object o) throws SerializationException {
+		try {
+			validateObject(o);
+		} catch(Throwable t) {
+			throw new SerializationException("Cannot serialize an invalid object", t);
+		}
+	}
+
+	protected void validateBytesAfterSerialization(byte[] serializedBytes) throws SerializationException {
+		try {
+			deserializeObjectFromByteArray(serializedBytes);
+		} catch(Throwable t) {
+			throw new SerializationException("Failed to serialize object since the resulting bytes cannot be deserialized properly", t);
+		}
+	}
+	
+	protected Object deserializeObjectFromByteArrayWithoutChecks(byte[] bytes) {
+		return toObject(bytes);
 	}
 
 	@Override
@@ -59,10 +101,10 @@ public class ThreadLocalFstSerializer extends ThreadLocal<DefaultCoder> implemen
 		Throwable failureCause = null;
 		
 		int retryCount = 0;
-		while(retryCount < MAX_DESERIALIZE_ATTEMPTS) {
+		while(retryCount < MAX_ATTEMPTS) {
 			try {
 				Object obj = toObject(bytes);
-				ObjectValidation.validateFieldValueTypesForObject(obj);
+				validateObject(obj);
 				return obj;
 			} catch(Throwable t) {
 				failureCause = t;
@@ -79,6 +121,14 @@ public class ThreadLocalFstSerializer extends ThreadLocal<DefaultCoder> implemen
 		} catch(Throwable t) {
 			byte[] bytesToTry = ByteUtils.replaceClassPathBytes(bytes, "io.bluedb", "org.bluedb");
 			return get().toObject(bytesToTry);
+		}
+	}
+
+	private void validateObject(Object obj) throws SerializationException {
+		try {
+			ObjectValidation.validateFieldValueTypesForObject(obj);
+		} catch(Throwable t) {
+			throw new SerializationException("Invalid Object Identified", t); //Don't try to put the object details in the message since any usage of the invalid field will throw an exception. The caused by will contain some good detail
 		}
 	}
 

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/ThreadLocalFstSerializer.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/ThreadLocalFstSerializer.java
@@ -49,7 +49,9 @@ public class ThreadLocalFstSerializer extends ThreadLocal<DefaultCoder> implemen
 		);
 	}
 
-	protected byte[] serializeObjectToByteArrayWithoutChecks(Object o) {
+	@Deprecated
+	/** Should only be used by tests */
+	public byte[] serializeObjectToByteArrayWithoutChecks(Object o) {
 		return get().toByteArray(o);
 	}
 
@@ -92,7 +94,9 @@ public class ThreadLocalFstSerializer extends ThreadLocal<DefaultCoder> implemen
 		}
 	}
 	
-	protected Object deserializeObjectFromByteArrayWithoutChecks(byte[] bytes) {
+	@Deprecated
+	/** Should only be used by tests */
+	public Object deserializeObjectFromByteArrayWithoutChecks(byte[] bytes) {
 		return toObject(bytes);
 	}
 

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/ThreadLocalFstSerializer.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/ThreadLocalFstSerializer.java
@@ -135,10 +135,17 @@ public class ThreadLocalFstSerializer extends ThreadLocal<DefaultCoder> implemen
 			throw new SerializationException("Invalid Object Identified", t); //Don't try to put the object details in the message since any usage of the invalid field will throw an exception. The caused by will contain some good detail
 		}
 	}
+	
+	@SuppressWarnings("unchecked")
+	@Deprecated
+	/** Should only be used by tests */
+	public <T extends Serializable> T cloneWithoutChecks(T object) {
+		return (T) deserializeObjectFromByteArrayWithoutChecks(serializeObjectToByteArrayWithoutChecks(object));
+	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends Serializable> T clone(T object) {
-		return (T) get().toObject(get().toByteArray(object));
+	public <T extends Serializable> T clone(T object) throws SerializationException {
+		return (T) deserializeObjectFromByteArray(serializeObjectToByteArray(object));
 	}
 }

--- a/BlueDBOnDisk/src/test/java/org/bluedb/TestUtils.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/TestUtils.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -14,6 +15,9 @@ import org.bluedb.api.keys.TimeFrameKey;
 import org.bluedb.api.keys.TimeKey;
 import org.bluedb.disk.IndexableTestValue;
 import org.bluedb.disk.collection.BlueCollectionOnDisk;
+import org.bluedb.disk.models.calls.Call;
+import org.bluedb.disk.serialization.BlueEntity;
+import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
 
 public class TestUtils {
 	public static Path getResourcePath(String relativePath) throws URISyntaxException, IOException {
@@ -22,6 +26,14 @@ public class TestUtils {
 			pathToStartFrom = pathToStartFrom.resolve("../").toRealPath();
 		}
 		return pathToStartFrom.resolve("src/test/resources").resolve(relativePath);
+	}
+
+	public static BlueEntity<Call> loadCorruptCall() throws URISyntaxException, IOException {
+		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		Path invalidObjectPath = TestUtils.getResourcePath("corruptCall-1.bin");
+		@SuppressWarnings({ "deprecation", "unchecked" })
+		BlueEntity<Call> invalidCall = (BlueEntity<Call>) serializer.deserializeObjectFromByteArrayWithoutChecks(Files.readAllBytes(invalidObjectPath));
+		return invalidCall;
 	}
 
 	public static void assertThrowable(Class<? extends Throwable> expected, Throwable error) {

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/BlueDbDiskTestBase.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/BlueDbDiskTestBase.java
@@ -29,6 +29,7 @@ import org.bluedb.disk.collection.BlueCollectionOnDisk;
 import org.bluedb.disk.collection.CollectionMetaData;
 import org.bluedb.disk.file.FileManager;
 import org.bluedb.disk.lock.LockManager;
+import org.bluedb.disk.models.calls.Call;
 import org.bluedb.disk.recovery.RecoveryManager;
 import org.bluedb.disk.segment.Segment;
 import org.bluedb.disk.segment.SegmentEntityIterator;
@@ -44,11 +45,13 @@ public abstract class BlueDbDiskTestBase extends TestCase {
 	private static String HASH_GROUPED_COLLECTION_NAME = "testing_value";
 	private static String LONG_COLLECTION_NAME = "long_value";
 	private static String INT_COLLECTION_NAME = "int_value";
+	private static String CALL_COLLECTION_NAME = "call_collection";
 	BlueDbOnDisk db;
 	BlueCollectionOnDisk<TestValue> timeCollection;
 	BlueCollectionOnDisk<TestValue> hashGroupedCollection;
 	BlueCollectionOnDisk<TestValue> intCollection;
 	BlueCollectionOnDisk<TestValue> longCollection;
+	BlueCollectionOnDisk<Call> callCollection;
 	Path dbPath;
 	LockManager<Path> lockManager;
 	RollupScheduler rollupScheduler;
@@ -64,6 +67,7 @@ public abstract class BlueDbDiskTestBase extends TestCase {
 		timeCollection = db.collectionBuilder(TIME_COLLECTION_NAME, TimeKey.class, TestValue.class).build();
 		hashGroupedCollection = db.collectionBuilder(HASH_GROUPED_COLLECTION_NAME, HashGroupedKey.class, TestValue.class).build();
 		longCollection = db.collectionBuilder(LONG_COLLECTION_NAME, LongKey.class, TestValue.class).build();
+		callCollection = db.collectionBuilder(CALL_COLLECTION_NAME, TimeFrameKey.class, Call.class).withOptimizedClasses(Call.getClassesToRegisterAsList()).build();
 		intCollection = db.collectionBuilder(INT_COLLECTION_NAME, IntegerKey.class, TestValue.class).build();
 		dbPath = db.getPath();
 		lockManager = timeCollection.getFileManager().getLockManager();
@@ -96,6 +100,10 @@ public abstract class BlueDbDiskTestBase extends TestCase {
 
 	public BlueCollectionOnDisk<TestValue> getLongCollection() {
 		return longCollection;
+	}
+	
+	public BlueCollectionOnDisk<Call> getCallCollection() {
+		return callCollection;
 	}
 	
 	public BlueCollectionOnDisk<TestValue> getIntCollection() {

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/BlueDbOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/BlueDbOnDiskTest.java
@@ -601,11 +601,11 @@ public class BlueDbOnDiskTest extends BlueDbDiskTestBase {
 	public void test_getAllCollectionsFromDisk() throws Exception {
         getTimeCollection();
         List<BlueCollectionOnDisk<?>> allCollections = db().getAllCollectionsFromDisk();
-        assertEquals(4, allCollections.size());
+        assertEquals(5, allCollections.size());
         db().collectionBuilder("string", HashGroupedKey.class, String.class).build();
         db().collectionBuilder("long", HashGroupedKey.class, Long.class).build();
         allCollections = db().getAllCollectionsFromDisk();
-        assertEquals(6, allCollections.size());
+        assertEquals(7, allCollections.size());
 	}
 
 	@Test

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/BlueCollectionOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/BlueCollectionOnDiskTest.java
@@ -3,6 +3,8 @@ package org.bluedb.disk.collection;
 import static org.junit.Assert.assertNotEquals;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -14,6 +16,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.bluedb.TestUtils;
 import org.bluedb.api.Condition;
 import org.bluedb.api.exceptions.BlueDbException;
 import org.bluedb.api.index.BlueIndex;
@@ -31,6 +34,7 @@ import org.bluedb.disk.BlueDbOnDiskBuilder;
 import org.bluedb.disk.Blutils;
 import org.bluedb.disk.TestValue;
 import org.bluedb.disk.collection.index.TestRetrievalKeyExtractor;
+import org.bluedb.disk.models.calls.Call;
 import org.bluedb.disk.segment.Range;
 import org.bluedb.disk.segment.Segment;
 import org.bluedb.disk.segment.SegmentManager;
@@ -202,6 +206,17 @@ public class BlueCollectionOnDiskTest extends BlueDbDiskTestBase {
 		}
 		List<String> storedValues = stringCollection.query().getList();
 		assertEquals(n, storedValues.size());
+	}
+
+	@Test
+	public void test_insert_invalid() throws BlueDbException, URISyntaxException, IOException {
+		BlueEntity<Call> invalidCall = TestUtils.loadCorruptCall();
+		
+		try {
+			getCallCollection().insert(invalidCall.getKey(), invalidCall.getValue());
+			fail();
+		} catch (BlueDbException e) {
+		}
 	}
 
 	@Test

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/task/ReplaceMultipleTaskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/task/ReplaceMultipleTaskTest.java
@@ -1,0 +1,52 @@
+package org.bluedb.disk.collection.task;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.bluedb.TestUtils;
+import org.bluedb.api.exceptions.BlueDbException;
+import org.bluedb.disk.collection.BlueCollectionOnDisk;
+import org.bluedb.disk.models.calls.Call;
+import org.bluedb.disk.recovery.IndividualChange;
+import org.bluedb.disk.serialization.BlueEntity;
+import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ReplaceMultipleTaskTest {
+
+	@Test
+	public void testCreateChangesWithInvalidObject() throws BlueDbException, URISyntaxException, IOException {
+		BlueEntity<Call> invalidCall = TestUtils.loadCorruptCall();
+		long invalidCallStart = invalidCall.getValue().getStart();
+		
+		List<BlueEntity<Call>> startingCalls = Arrays.asList(
+				Call.generateBasicTestCallEntity(invalidCallStart - 10),
+				invalidCall,
+				Call.generateBasicTestCallEntity(invalidCallStart + 10)
+		); 
+		
+		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		
+		@SuppressWarnings("unchecked")
+		BlueCollectionOnDisk<Call> collectionMock = Mockito.mock(BlueCollectionOnDisk.class);
+		Mockito.when(collectionMock.getSerializer()).thenReturn(serializer);
+		
+		ReplaceMultipleTask<Call> task = new ReplaceMultipleTask<>(collectionMock, null, null);
+		List<IndividualChange<Call>> changes = task.createChanges(startingCalls, call -> {
+			Call clone = call.clone();
+			clone.setReceivingParty("testParty");	
+			return clone;
+		});
+		
+		//Changes should not include the invalid object but should still include the other two
+		assertFalse(changes.stream().anyMatch(call -> call.getKey().equals(invalidCall.getKey())));
+		assertEquals(2, changes.size());
+		assertTrue(changes.stream().allMatch(call -> "testParty".equals(call.getNewValue().getReceivingParty())));
+	}
+
+}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/task/UpdateMultipleTaskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/task/UpdateMultipleTaskTest.java
@@ -1,0 +1,50 @@
+package org.bluedb.disk.collection.task;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.bluedb.TestUtils;
+import org.bluedb.api.exceptions.BlueDbException;
+import org.bluedb.disk.collection.BlueCollectionOnDisk;
+import org.bluedb.disk.models.calls.Call;
+import org.bluedb.disk.recovery.IndividualChange;
+import org.bluedb.disk.serialization.BlueEntity;
+import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class UpdateMultipleTaskTest {
+
+	@Test
+	public void testCreateChangesWithInvalidObject() throws BlueDbException, URISyntaxException, IOException {
+		BlueEntity<Call> invalidCall = TestUtils.loadCorruptCall();
+		long invalidCallStart = invalidCall.getValue().getStart();
+		
+		List<BlueEntity<Call>> startingCalls = Arrays.asList(
+				Call.generateBasicTestCallEntity(invalidCallStart - 10),
+				invalidCall,
+				Call.generateBasicTestCallEntity(invalidCallStart + 10)
+		); 
+		
+		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		
+		@SuppressWarnings("unchecked")
+		BlueCollectionOnDisk<Call> collectionMock = Mockito.mock(BlueCollectionOnDisk.class);
+		Mockito.when(collectionMock.getSerializer()).thenReturn(serializer);
+		
+		UpdateMultipleTask<Call> task = new UpdateMultipleTask<>(collectionMock, null, null);
+		List<IndividualChange<Call>> changes = task.createChanges(startingCalls, call -> call.setReceivingParty("testParty"));
+		
+		//Changes should not include the invalid object but should still include the other two
+		assertFalse(changes.stream().anyMatch(call -> call.getKey().equals(invalidCall.getKey())));
+		assertEquals(2, changes.size());
+		assertTrue(changes.stream().allMatch(call -> "testParty".equals(call.getNewValue().getReceivingParty())));
+	}
+
+}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/models/calls/Call.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/models/calls/Call.java
@@ -2,11 +2,13 @@ package org.bluedb.disk.models.calls;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
 import org.bluedb.api.keys.TimeFrameKey;
+import org.bluedb.disk.serialization.BlueEntity;
 
 public class Call implements Serializable {
 	private static final long serialVersionUID = 1L;
@@ -138,6 +140,18 @@ public class Call implements Serializable {
 	public void setEvents(List<CallEvent> events) {
 		this.events = events;
 	}
+	
+	public static BlueEntity<Call> generateBasicTestCallEntity() {
+		return wrapCallAsEntity(generateBasicTestCall());
+	}
+	
+	public static BlueEntity<Call> generateBasicTestCallEntity(long start) {
+		return wrapCallAsEntity(generateBasicTestCall(start));
+	}
+	
+	public static BlueEntity<Call> wrapCallAsEntity(Call call) {
+		return new BlueEntity<Call>(call.createTimeframeKey(), call);
+	}
 
 	public static Call generateBasicTestCall() {
 		return generateBasicTestCall(-1);
@@ -177,9 +191,14 @@ public class Call implements Serializable {
 		Call call = new Call(callId, callDirection, callerId, callingParty, receivingParty, group, callStart, callEnd, tag, accountCodes, notes, events);
 		return call;
 	}
+	
+	public static List<Class<? extends Serializable>> getClassesToRegisterAsList() {
+		return Arrays.asList(getClassesToRegister());
+	}
 
-	public static Class<?>[] getClassesToRegister() {
-		return new Class<?>[] {
+	@SuppressWarnings("unchecked")
+	public static Class<? extends Serializable>[] getClassesToRegister() {
+		return (Class<? extends Serializable>[]) new Class<?>[] {
 			UUID.class,
 			CallDirection.class,
 			Note.class,

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/models/calls/Call.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/models/calls/Call.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
+import org.bluedb.api.keys.TimeFrameKey;
+
 public class Call implements Serializable {
 	private static final long serialVersionUID = 1L;
 	
@@ -137,9 +139,11 @@ public class Call implements Serializable {
 		this.events = events;
 	}
 
-
-	
 	public static Call generateBasicTestCall() {
+		return generateBasicTestCall(-1);
+	}
+	
+	public static Call generateBasicTestCall(long start) {
 		Random r = new Random();
 		
 		UUID callId = UUID.randomUUID();
@@ -147,7 +151,7 @@ public class Call implements Serializable {
 		String group = "";
 		String tag = "";
 		
-		long callStart = r.nextInt(1_000_000);
+		long callStart = start >= 0 ? start : r.nextInt(1_000_000);
 		long ringStart = callStart + r.nextInt(30_000);
 		long talkStart = ringStart + r.nextInt(30_000);
 		long callEnd = talkStart + r.nextInt(30_000);
@@ -216,5 +220,13 @@ public class Call implements Serializable {
 				return;
 			}
 		}
+	}
+	
+	public TimeFrameKey createTimeframeKey() {
+		return new TimeFrameKey(id, start, end);
+	}
+	
+	public Call clone() {
+		return new Call(id, callDirection, callerId, callingParty, receivingParty, group, start, end, tag, accountCodes, notes, events);
 	}
 }

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/performance/PerformanceTests.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/performance/PerformanceTests.java
@@ -149,7 +149,7 @@ public class PerformanceTests {
 		}
 	}
 
-	private void serializeListToFileOneObjectAtATime() throws FileNotFoundException, IOException {
+	private void serializeListToFileOneObjectAtATime() throws FileNotFoundException, IOException, SerializationException {
 		try(DataOutputStream dos = new DataOutputStream(new FileOutputStream(file.toFile()))) {
 			for(TestValue value : values) {
 				byte[] bytes = serializer.serializeObjectToByteArray(value);
@@ -210,7 +210,7 @@ public class PerformanceTests {
 //		return values;
 //	}
 
-	private void serializeObject(Object obj) throws FileNotFoundException, IOException {
+	private void serializeObject(Object obj) throws FileNotFoundException, IOException, SerializationException {
 		byte[] bytes = serializer.serializeObjectToByteArray(obj);
 
 		try(FileOutputStream fos = new FileOutputStream(file.toFile())) {

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/recovery/PendingChangeTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/recovery/PendingChangeTest.java
@@ -8,6 +8,7 @@ import org.bluedb.disk.BlueDbDiskTestBase;
 import org.bluedb.disk.TestValue;
 import org.bluedb.disk.segment.Segment;
 import org.bluedb.disk.serialization.BlueEntity;
+import org.bluedb.disk.serialization.validation.SerializationException;
 
 public class PendingChangeTest extends BlueDbDiskTestBase {
 
@@ -24,7 +25,7 @@ public class PendingChangeTest extends BlueDbDiskTestBase {
 	}
 
 	@Test
-	public void test_createInsert() {
+	public void test_createInsert() throws SerializationException {
 		BlueKey key = createKey(1, 2);
 		TestValue value = createValue("Joe");
 		PendingChange<TestValue> change = PendingChange.createInsert(key, value, getSerializer());
@@ -37,7 +38,7 @@ public class PendingChangeTest extends BlueDbDiskTestBase {
 	}
 
 	@Test
-	public void test_createUpdate() {
+	public void test_createUpdate() throws SerializationException {
 		BlueKey key = createKey(1, 2);
 		TestValue initialValue = createValue("Joe");
 		Updater<TestValue> updater = ((v) -> v.addCupcake());
@@ -151,7 +152,7 @@ public class PendingChangeTest extends BlueDbDiskTestBase {
 	}
 
 	@Test
-	public void test_DeleteMultipleTask_toString() {
+	public void test_DeleteMultipleTask_toString() throws SerializationException {
 		BlueKey key = createKey(1, 2);
 		TestValue value = createValue("Joe");
 		Updater<TestValue> updater = ((v) -> v.addCupcake());

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/segment/writer/BatchWriterTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/segment/writer/BatchWriterTest.java
@@ -1,26 +1,35 @@
 package org.bluedb.disk.segment.writer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyObject;
 
+import java.io.IOException;
 import java.io.Serializable;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
+import org.bluedb.TestUtils;
 import org.bluedb.api.exceptions.BlueDbException;
 import org.bluedb.api.keys.BlueKey;
 import org.bluedb.api.keys.LongKey;
 import org.bluedb.disk.file.BlueObjectInput;
 import org.bluedb.disk.file.BlueObjectOutput;
+import org.bluedb.disk.models.calls.Call;
 import org.bluedb.disk.recovery.IndividualChange;
 import org.bluedb.disk.serialization.BlueEntity;
+import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
+import org.bluedb.disk.serialization.validation.ObjectValidation;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 public class BatchWriterTest {
 	
@@ -43,14 +52,16 @@ public class BatchWriterTest {
 	private static IndividualChange<String> insert1 = new IndividualChange<>(key1, null, "1");
 
 	private static IndividualChange<String> update5bAt5 = new IndividualChange<>(key5, "5", "5b");
+	
+	private ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(new Class<?>[] { });
 
 	@Test
 	public void testDeletes() throws Exception {
 		List<BlueEntity<String>> initialValues = Arrays.asList(value3at3, value5at5, value7at7);
-		BlueObjectInput<BlueEntity<String>> mockInput = createMockInput(initialValues);
+		BlueObjectInput<BlueEntity<String>> mockInput = createMockInput(serializer, initialValues);
 		
 		List<BlueEntity<String>> results = new ArrayList<>();
-		BlueObjectOutput<BlueEntity<String>> mockOutput = createMockOutput(results);
+		BlueObjectOutput<BlueEntity<String>> mockOutput = createMockOutput(serializer, results);
 
 		List<IndividualChange<String>> deletes2and3and5and8 = Arrays.asList(delete2, delete3, delete5, delete8);
 		BatchWriter<String> batchDeletes2and3and5and8 = new BatchWriter<>(deletes2and3and5and8);
@@ -62,10 +73,10 @@ public class BatchWriterTest {
 	@Test
 	public void testUpdateAndInsert() throws Exception {
 		List<BlueEntity<String>> initialValues = Arrays.asList(value3at3, value5at5, value7at7);
-		BlueObjectInput<BlueEntity<String>> mockInput = createMockInput(initialValues);
+		BlueObjectInput<BlueEntity<String>> mockInput = createMockInput(serializer, initialValues);
 		
 		List<BlueEntity<String>> results = new ArrayList<>();
-		BlueObjectOutput<BlueEntity<String>> mockOutput = createMockOutput(results);
+		BlueObjectOutput<BlueEntity<String>> mockOutput = createMockOutput(serializer, results);
 
 		List<IndividualChange<String>> insert1andUpdate5 = Arrays.asList(insert1, update5bAt5);
 		BatchWriter<String> batchInsert1andUpdate5 = new BatchWriter<>(insert1andUpdate5);
@@ -73,30 +84,175 @@ public class BatchWriterTest {
 		
 		assertEquals(Arrays.asList(value1at1, value3at3, value5bAt5, value7at7), results);
 	}
-
-	private static <T extends Serializable> BlueObjectInput<T> createMockInput(List<T> values) throws BlueDbException {
-		final LinkedList<T> inputValues = new LinkedList<>(values);
-		@SuppressWarnings("unchecked")
-		BlueObjectInput<T> mockOutput = Mockito.mock(BlueObjectInput.class);
-		Mockito.doAnswer((x) -> !inputValues.isEmpty()).when(mockOutput).hasNext();
-		Mockito.doAnswer((x) -> inputValues.poll()).when(mockOutput).next();
-		Mockito.doAnswer((x) -> inputValues.peek()).when(mockOutput).peek();
-		return mockOutput;
+	
+	@Test
+	public void testUpdatingInvalidObjectThenMakingOtherChanges() throws BlueDbException, IOException, URISyntaxException {
+		serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		
+		BlueEntity<Call> call1 = createTestCallEntity(920832 - 10);
+		@SuppressWarnings({ "unchecked", "deprecation" })
+		BlueEntity<Call> invalidCall = (BlueEntity<Call>) serializer.deserializeObjectFromByteArrayWithoutChecks(getResourceBytes("corruptCall-1.bin"));
+		BlueEntity<Call> call3 = createTestCallEntity(920832 + 10);
+		BlueEntity<Call> call4 = createTestCallEntity(920832 + 20);
+		BlueEntity<Call> call5 = createTestCallEntity(920832 + 30);
+		
+		@SuppressWarnings("deprecation")
+		BlueEntity<Call> updatedInvalidCall = serializer.cloneWithoutChecks(invalidCall);
+		updatedInvalidCall.getValue().setReceivingParty("testChange");
+		
+		BlueEntity<Call> updatedcall4 = wrapCallAsEntity(call4.getValue().clone());
+		updatedcall4.getValue().setCallingParty("testChange");
+		
+		List<BlueEntity<Call>> initialValues = new LinkedList<>(Arrays.asList(call1, invalidCall, call4, call5));
+		BlueObjectInput<BlueEntity<Call>> mockInput = createMockInput(serializer, initialValues);
+		
+		List<BlueEntity<Call>> results = new ArrayList<>();
+		BlueObjectOutput<BlueEntity<Call>> mockOutput = createMockOutput(serializer, results);
+		
+		IndividualChange<Call> updateInvalidCall = new IndividualChange<Call>(invalidCall.getKey(), invalidCall.getValue(), updatedInvalidCall.getValue());
+		IndividualChange<Call> insert3 = IndividualChange.createInsertChange(call3.getKey(), call3.getValue());
+		IndividualChange<Call> update4 = new IndividualChange<Call>(call4.getKey(), call4.getValue(), updatedcall4.getValue());
+		IndividualChange<Call> delete5 = IndividualChange.createDeleteChange(call5.getKey());
+		
+		BatchWriter<Call> batchWriter = new BatchWriter<Call>(Arrays.asList(updateInvalidCall, insert3, update4, delete5));
+		batchWriter.process(mockInput, mockOutput);
+		
+		BlueEntity<Call> resultingCall1 = results.stream().filter(callEntity -> callEntity.getKey().equals(call1.getKey())).findAny().orElse(null);
+		BlueEntity<Call> resultingInvalidCall = results.stream().filter(callEntity -> callEntity.getKey().equals(invalidCall.getKey())).findAny().orElse(null);
+		BlueEntity<Call> resultingCall3 = results.stream().filter(callEntity -> callEntity.getKey().equals(call3.getKey())).findAny().orElse(null);
+		BlueEntity<Call> resultingCall4 = results.stream().filter(callEntity -> callEntity.getKey().equals(call4.getKey())).findAny().orElse(null);
+		BlueEntity<Call> resultingCall5 = results.stream().filter(callEntity -> callEntity.getKey().equals(call5.getKey())).findAny().orElse(null);
+		
+		assertNotNull(resultingCall1); //This call was unchanged
+		
+		assertNotNull(resultingInvalidCall);
+		assertNotEquals("testChange", resultingInvalidCall.getValue().getReceivingParty()); //Change won't be made because the new object failed to serialize properly
+		
+		assertNotNull(resultingCall3); //Call was successfully inserted
+		
+		assertNotNull(resultingCall4);
+		assertEquals("testChange", resultingCall4.getValue().getCallingParty()); //Call was successfully updated
+		
+		assertNull(resultingCall5); //Call was successfully deleted
+	}
+	
+	@Test
+	public void testDeletingInvalidObjectThenMakingOtherChanges() throws URISyntaxException, IOException, BlueDbException {
+		serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		
+		@SuppressWarnings({ "unchecked", "deprecation" })
+		BlueEntity<Call> invalidCall = (BlueEntity<Call>) serializer.deserializeObjectFromByteArrayWithoutChecks(getResourceBytes("corruptCall-1.bin"));
+		BlueEntity<Call> call2 = createTestCallEntity(920832 + 20);
+		
+		List<BlueEntity<Call>> initialValues = new LinkedList<>(Arrays.asList(invalidCall, call2));
+		BlueObjectInput<BlueEntity<Call>> mockInput = createMockInput(serializer, initialValues);
+		
+		List<BlueEntity<Call>> results = new ArrayList<>();
+		BlueObjectOutput<BlueEntity<Call>> mockOutput = createMockOutput(serializer, results);
+		
+		BlueEntity<Call> updatedcall2 = wrapCallAsEntity(call2.getValue().clone());
+		updatedcall2.getValue().setCallingParty("testChange2");
+		
+		IndividualChange<Call> deleteInvalidObject = IndividualChange.createDeleteChange(invalidCall.getKey());
+		IndividualChange<Call> update4Again = new IndividualChange<Call>(call2.getKey(), call2.getValue(), updatedcall2.getValue());
+		
+		BatchWriter<Call> batchWriter = new BatchWriter<Call>(Arrays.asList(deleteInvalidObject, update4Again));
+		batchWriter.process(mockInput, mockOutput);
+		
+		BlueEntity<Call> resultingInvalidCall = results.stream().filter(callEntity -> callEntity.getKey().equals(invalidCall.getKey())).findAny().orElse(null);
+		BlueEntity<Call> resultingCall2 = results.stream().filter(callEntity -> callEntity.getKey().equals(call2.getKey())).findAny().orElse(null);
+		
+		assertNull(resultingInvalidCall); //Delete an invalid call should still work
+		
+		assertNotNull(resultingCall2);
+		assertEquals("testChange2", resultingCall2.getValue().getCallingParty()); //Update should still happen
+	}
+	
+	@Test
+	public void testInsertingInvalidObjectThenMakingOtherUpdates() throws BlueDbException, IOException, URISyntaxException {
+		serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		
+		@SuppressWarnings({ "unchecked", "deprecation" })
+		BlueEntity<Call> invalidCall = (BlueEntity<Call>) serializer.deserializeObjectFromByteArrayWithoutChecks(getResourceBytes("corruptCall-1.bin"));
+		BlueEntity<Call> call2 = createTestCallEntity(920832 + 20);
+		
+		List<BlueEntity<Call>> initialValues = new LinkedList<>(Arrays.asList(call2));
+		BlueObjectInput<BlueEntity<Call>> mockInput = createMockInput(serializer, initialValues);
+		
+		List<BlueEntity<Call>> results = new ArrayList<>();
+		BlueObjectOutput<BlueEntity<Call>> mockOutput = createMockOutput(serializer, results);
+		
+		BlueEntity<Call> updatedcall2 = wrapCallAsEntity(call2.getValue().clone());
+		updatedcall2.getValue().setCallingParty("testChange3");
+		
+		IndividualChange<Call> insertInvalidObject = IndividualChange.createInsertChange(invalidCall.getKey(), invalidCall.getValue());
+		IndividualChange<Call> updateCall4AThirdTime = new IndividualChange<Call>(call2.getKey(), updatedcall2.getValue(), updatedcall2.getValue());
+		
+		BatchWriter<Call> batchWriter = new BatchWriter<Call>(Arrays.asList(insertInvalidObject, updateCall4AThirdTime));
+		batchWriter.process(mockInput, mockOutput);
+		
+		BlueEntity<Call> resultingInvalidCall = results.stream().filter(callEntity -> callEntity.getKey().equals(invalidCall.getKey())).findAny().orElse(null);
+		BlueEntity<Call> resultingCall2 = results.stream().filter(callEntity -> callEntity.getKey().equals(call2.getKey())).findAny().orElse(null);
+		
+		assertNull(resultingInvalidCall); //Insert should fail since the object cannot be serialized correctly
+		
+		assertNotNull(resultingCall2);
+		assertEquals("testChange3", resultingCall2.getValue().getCallingParty()); //Update should still happen
 	}
 
-	private static <T extends Serializable> BlueObjectOutput<T> createMockOutput(List<T> results) throws BlueDbException {
+	private BlueEntity<Call> createTestCallEntity(long start) {
+		Call call = Call.generateBasicTestCall(start);
+		return wrapCallAsEntity(call);
+	}
+	
+	private BlueEntity<Call> wrapCallAsEntity(Call call) {
+		return new BlueEntity<Call>(call.createTimeframeKey(), call);
+	}
+	
+	private byte[] getResourceBytes(String filepath) throws IOException, URISyntaxException {
+		return Files.readAllBytes(TestUtils.getResourcePath(filepath));
+	}
+
+	private static <T extends Serializable> BlueObjectInput<T> createMockInput(ThreadLocalFstSerializer serializer, List<T> values) throws BlueDbException {
+		final LinkedList<T> inputValues = new LinkedList<>(values);
+		@SuppressWarnings("unchecked")
+		BlueObjectInput<T> mockInput = Mockito.mock(BlueObjectInput.class);
+		Mockito.doAnswer((x) -> !inputValues.isEmpty()).when(mockInput).hasNext();
+		Mockito.doAnswer((x) -> inputValues.poll()).when(mockInput).next();
+		Mockito.doAnswer((x) -> serializer.serializeObjectToByteArrayWithoutChecks(inputValues.poll())).when(mockInput).nextWithoutDeserializing();
+		Mockito.doAnswer((x) -> inputValues.peek()).when(mockInput).peek();
+		return mockInput;
+	}
+
+	private static <T extends Serializable> BlueObjectOutput<T> createMockOutput(ThreadLocalFstSerializer serializer, List<T> results) throws BlueDbException {
 		@SuppressWarnings("unchecked")
 		BlueObjectOutput<T> mockOutput = Mockito.mock(BlueObjectOutput.class);
-		Answer<T> mockAnswer = new Answer<T>() {
+		
+		Answer<T> writeObjectMethod = new Answer<T>() {
 			@Override
 			public T answer(InvocationOnMock invocation) throws Throwable {
 				@SuppressWarnings("unchecked")
 				T outputValue = (T) invocation.getArguments()[0];
+				
+				ObjectValidation.validateFieldValueTypesForObject(outputValue);
+				
 				results.add(outputValue);
 				return null;
 			}
 		};
-		Mockito.doAnswer(mockAnswer).when(mockOutput).write(anyObject());
+		
+		Answer<T> writeBytesMethod = new Answer<T>() {
+			@SuppressWarnings("unchecked")
+			@Override
+			public T answer(InvocationOnMock invocation) throws Throwable {
+				byte[] outputValueBytes = (byte[]) invocation.getArguments()[0];
+				results.add((T)serializer.deserializeObjectFromByteArrayWithoutChecks(outputValueBytes));
+				return null;
+			}
+		};
+		
+		Mockito.doAnswer(writeObjectMethod).when(mockOutput).write(anyObject());
+		Mockito.doAnswer(writeBytesMethod).when(mockOutput).writeBytes(anyObject());
 		return mockOutput;
 	}
 }

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/serialization/ThreadLocalFstSerializerTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/serialization/ThreadLocalFstSerializerTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,7 +30,12 @@ import org.junit.Test;
 public class ThreadLocalFstSerializerTest {
 	
 	@Test
-	public void testStaticRegisteredClassesProblem() {
+	public void testStaticRegisteredClassesProblem() throws SerializationException {
+		/*
+		 * I found a weird issue with FST that I was able to work around by changing how we
+		 * use FST a little bit. This test keeps someone from changing it back to the other way
+		 * since that way has an issue.
+		 */
 		ThreadLocalFstSerializer s1 = new ThreadLocalFstSerializer(TestValue.class);
 		TestValue value1 = new TestValue("Derek", 1);
 		TestValue clone1 = s1.clone(value1);
@@ -63,8 +66,7 @@ public class ThreadLocalFstSerializerTest {
 	@Test
 	public void testSerializingInvalidObject() throws URISyntaxException, BlueDbException, IOException {
 		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
-		Path invalidObjectPath = TestUtils.getResourcePath("corruptCall-1.bin");
-		Object invalidObject = serializer.deserializeObjectFromByteArrayWithoutChecks(Files.readAllBytes(invalidObjectPath));
+		Object invalidObject = TestUtils.loadCorruptCall();
 		
 		try {
 			serializer.validateObjectBeforeSerializing(invalidObject);


### PR DESCRIPTION
We check for FST serialization mistakes when cloning objects and when serializing objects to bytes now. We used to only check when deserializing bytes into objects.