### PR TITLE
Versioned serialized_classes files

### DIFF
--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/BlueDbOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/BlueDbOnDiskTest.java
@@ -17,6 +17,8 @@ import org.bluedb.api.keys.BlueKey;
 import org.bluedb.api.keys.HashGroupedKey;
 import org.bluedb.api.keys.TimeKey;
 import org.bluedb.disk.collection.BlueCollectionOnDisk;
+import org.bluedb.disk.collection.CollectionMetaData;
+import org.bluedb.disk.file.FileManager;
 import org.bluedb.tasks.AsynchronousTestTask;
 import org.bluedb.tasks.TestTask;
 import org.bluedb.zip.ZipUtils;
@@ -642,7 +644,7 @@ public class BlueDbOnDiskTest extends BlueDbDiskTestBase {
 	public void test_backup_fail() throws Exception {
 		@SuppressWarnings("rawtypes")
         BlueCollectionOnDisk newUntypedCollection = db.getUntypedCollectionForBackup(getTimeCollectionName());
-        Path serializedClassesPath = Paths.get(newUntypedCollection.getPath().toString(), ".meta", "serialized_classes");
+        Path serializedClassesPath = FileManager.getNewestVersionPath(newUntypedCollection.getPath().resolve(".meta"), CollectionMetaData.FILENAME_SERIALIZED_CLASSES);
         getFileManager().saveObject(serializedClassesPath, "some_nonsense");  // serialize a string where there should be a list
 
         Path tempFolder = createTempFolder().toPath();

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/FileManagerTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/FileManagerTest.java
@@ -154,6 +154,8 @@ public class FileManagerTest extends TestCase {
 		Files.createFile(legacyPath);
 		testPaths.add(legacyPath);
 		
+		assertEquals(legacyPath, FileManager.getNewestVersionPath(tempDirPath, filename));
+		
 		long maxTime = -1;
 		Path maxPath = null;
 		for(int i = 0; i < 1000; i++) {


### PR DESCRIPTION
This makes the serialized classes collection meta data file be versioned/timestamped 
instead of being overwritten. Knowing what order classes were registered to the collection 
is super important and this gives us a trail so that recovery is easier if something happens 
to the most recent file.