### PR TITLE
Iterator keep alive

### DIFF
--- a/BlueDB/src/main/java/org/bluedb/api/CloseableIterator.java
+++ b/BlueDB/src/main/java/org/bluedb/api/CloseableIterator.java
@@ -9,4 +9,6 @@ import java.util.Iterator;
  */
 public interface CloseableIterator<V> extends Closeable, Iterator<V> {
 	public V peek();
+	
+	public void keepAlive();
 }

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/CollectionEntityIterator.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/CollectionEntityIterator.java
@@ -109,4 +109,9 @@ public class CollectionEntityIterator<T extends Serializable> implements Closeab
 		ReadableSegment<T> segment = segments.remove(0);
 		return segment.getIterator(endGroupingValueOfCompletedSegments, range);
 	}
+
+	@Override
+	public void keepAlive() {
+		
+	}
 }

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/CollectionValueIterator.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/CollectionValueIterator.java
@@ -65,4 +65,8 @@ public class CollectionValueIterator<T extends Serializable> implements Closeabl
 		timeoutCloser.snooze();
 		return entityIterator.next().getValue();
 	}
+	
+	public void keepAlive() {
+		timeoutCloser.snooze();
+	}
 }

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/CollectionValueIterator.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/CollectionValueIterator.java
@@ -66,6 +66,7 @@ public class CollectionValueIterator<T extends Serializable> implements Closeabl
 		return entityIterator.next().getValue();
 	}
 	
+	@Override
 	public void keepAlive() {
 		timeoutCloser.snooze();
 	}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/query/DummyQuery.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/query/DummyQuery.java
@@ -37,6 +37,11 @@ public class DummyQuery<T extends Serializable> extends ReadOnlyTimeQueryOnDisk<
 			public T peek() {
 				return null;
 			}
+
+			@Override
+			public void keepAlive() {
+				
+			}
 			
 		};
 	}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/CollectionEntityIteratorTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/CollectionEntityIteratorTest.java
@@ -73,6 +73,7 @@ public class CollectionEntityIteratorTest extends BlueDbDiskTestBase {
         getTimeCollection().insert(key2, value2);
         CollectionEntityIterator<TestValue> iterator = new CollectionEntityIterator<>(getTimeSegmentManager(), new Range(0, 0), false, new ArrayList<>());
     	assertNull(iterator.peek());
+    	iterator.keepAlive();
         iterator.close();
 
         iterator = new CollectionEntityIterator<>(getTimeSegmentManager(), new Range(1, 1), false, new ArrayList<>());

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/CollectionValueIteratorTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/CollectionValueIteratorTest.java
@@ -159,6 +159,13 @@ public class CollectionValueIteratorTest extends BlueDbDiskTestBase {
 			assertEquals(value1, first);
 
 			assertTrue(lockManager.isLocked(firstFilePath));
+
+			for(int i = 0; i < 10; i++) {
+				Blutils.trySleep(6);
+				iterator.keepAlive();
+				assertTrue(lockManager.isLocked(firstFilePath)); //Keep alive should keep it from closing
+			}
+			
 			Blutils.trySleep(60); // let the iterator auto-close
 			assertFalse(lockManager.isLocked(firstFilePath));  // make sure the lock is released
 			

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/DummyReadOnlyCollectionOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/DummyReadOnlyCollectionOnDiskTest.java
@@ -46,6 +46,7 @@ public class DummyReadOnlyCollectionOnDiskTest {
 		assertFalse(dummyIterator.hasNext());
 		assertEquals(null, dummyIterator.next());
 		assertEquals(null, dummyIterator.peek());
+		dummyIterator.keepAlive();
 		dummyIterator.close();
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'java'
-version = '2.1.0'
+version = '2.1.1'
 
 subprojects {
     apply plugin: 'java'


### PR DESCRIPTION
Added a way to keep an iterator alive without calling next. This can be
very useful when a client is iterating through multiple collections at a
time in chronological order. It should be used carefully those since
there can be repercussions from keeping an iterator stopped in a single
file for a long time.