### PR TITLE
only rollup index if it exists

### DIFF
--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadWriteCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadWriteCollectionOnDisk.java
@@ -200,7 +200,9 @@ public class ReadWriteCollectionOnDisk<T extends Serializable> extends ReadableC
 
 	public void rollupIndex(String indexName, Range range) throws BlueDbException {
 		ReadWriteIndexOnDisk<?, T> index = indexManager.getUntypedIndex(indexName);
-		index.rollup(range);
+		if (index != null) {
+			index.rollup(range);
+		}
 	}
 
 	//TODO: getIndex needs to work even if they haven't called initialize or build. Return empty index object if it doesn't exist


### PR DESCRIPTION
backup ignores indexes

the indexes get repopulated when the index is requested by the application using bluedb

if an index rollup is happening during backup, restore has a NullPointerException because the index isn't created yet on the restored database.

so let's ignore index rollups if the index doesn't exist.