### PR TITLE
Fixes an issue with creating read only collections that were created before we started saving segment size meta data.

### DIFF
--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadOnlyCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadOnlyCollectionOnDisk.java
@@ -44,7 +44,7 @@ public class ReadOnlyCollectionOnDisk<T extends Serializable> extends ReadableCo
 	}
 
 	@Override
-	protected Class<? extends Serializable>[] getClassesToRegister(Class<? extends BlueKey> requestedKeyType, List<Class<? extends Serializable>> additionalRegisteredClasses) throws BlueDbException {
+	protected Class<? extends Serializable>[] getClassesToRegister(List<Class<? extends Serializable>> additionalRegisteredClasses) throws BlueDbException {
 		// NOTE: don't need additionalRegisteredClasses since we only care about already serialized classes.
 		List<Class<? extends Serializable>> classesToRegister = metadata.getSerializedClassList();
 		@SuppressWarnings("unchecked")

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadWriteCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadWriteCollectionOnDisk.java
@@ -187,7 +187,7 @@ public class ReadWriteCollectionOnDisk<T extends Serializable> extends ReadableC
 	}
 
 	@Override
-	protected Class<? extends Serializable>[] getClassesToRegister(Class<? extends BlueKey> requestedKeyType, List<Class<? extends Serializable>> additionalRegisteredClasses) throws BlueDbException {
+	protected Class<? extends Serializable>[] getClassesToRegister(List<Class<? extends Serializable>> additionalRegisteredClasses) throws BlueDbException {
 		return metadata.getAndAddToSerializedClassList(getType(), additionalRegisteredClasses);
 
 	}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadOnlyDbOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadOnlyDbOnDiskTest.java
@@ -89,6 +89,19 @@ public class ReadOnlyDbOnDiskTest extends BlueDbDiskTestBase {
 		assertEquals(collection, readOnlyDb.getCollection(getTimeCollectionName(), TestValue.class));
 		assertNull(db.getCollection("non-existing", TestValue.class));
 	}
+	
+	@Test
+	public void test_getCollection_noSegmentSizeMetaData() throws Exception {
+		Path segmentSizePath = db.getPath().resolve("testing_time/.meta/segment_size");
+		Files.delete(db.getPath().resolve(segmentSizePath));
+		
+		ReadableDbOnDisk readOnlyDb = (ReadableDbOnDisk) (new BlueDbOnDiskBuilder()).withPath(db.getPath()).buildReadOnly();
+		ReadableBlueCollection<TestValue> collection = readOnlyDb.getTimeCollection(getTimeCollectionName(), TestValue.class);
+		assertNotNull(collection);
+		assertEquals(collection, readOnlyDb.getCollection(getTimeCollectionName(), TestValue.class));
+		assertNull(db.getCollection("non-existing", TestValue.class));
+		assertFalse(Files.exists(segmentSizePath));
+	}
 
 	@Test
 	public void test_getCollection_wrong_type() throws Exception {

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadableDbOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadableDbOnDiskTest.java
@@ -1,5 +1,6 @@
 package org.bluedb.disk;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -60,6 +61,16 @@ public class ReadableDbOnDiskTest extends BlueDbDiskTestBase {
 		assertNotNull(collection);
 		assertEquals(collection, db.getCollection(getTimeCollectionName(), TestValue.class));
 		assertNull(db.getCollection("non-existing", TestValue.class));
+	}
+
+	@Test
+	public void test_getCollection_noSegmentSizeMetaData() throws Exception {
+		Path segmentSizePath = db.getPath().resolve("testing_time/.meta/segment_size");
+		Files.delete(segmentSizePath);
+		
+		ReadWriteDbOnDisk newDb = (ReadWriteDbOnDisk) (new BlueDbOnDiskBuilder()).withPath(db.getPath()).build();
+		newDb.getTimeCollectionBuilder(getTimeCollectionName(), TimeKey.class, TestValue.class).build();
+		assertTrue(Files.exists(segmentSizePath));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes an issue with creating read only collections that were created
before we started saving segment size meta data. If those same
collections are initialized by a read/write instance of bluedb then it
will now create the meta data file.