### PR TITLE
Updated AutoCloseCountdown code to help resolve query iterator auto timeout issues

### DIFF
--- a/BlueDB/src/main/java/org/bluedb/api/ReadBlueQuery.java
+++ b/BlueDB/src/main/java/org/bluedb/api/ReadBlueQuery.java
@@ -2,6 +2,7 @@ package org.bluedb.api;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.bluedb.api.exceptions.BlueDbException;
 
@@ -41,6 +42,22 @@ public interface ReadBlueQuery<V extends Serializable> {
 	 * @throws BlueDbException 
 	 */
 	CloseableIterator<V> getIterator() throws BlueDbException;
+
+	/**
+	 * Begins executing the query and returns an iterator for processing the results. BlueDB will iterate over
+	 * the collection on disk as you iterate over it in memory. This makes the iterator an extremely memory efficient
+	 * way to read large collections. 
+	 * 
+	 * <br><br>
+	 * 
+	 * <b>Important: </b>Use within a try-with-resources statement and iterate through as quickly as possible
+	 * in order to ensure that you don't block other BlueDB tasks. If you fail to call next for the given timeout period then
+	 * the iterator will timeout and release resources.
+	 * 
+	 * @return an iterator for the query results
+	 * @throws BlueDbException 
+	 */
+	CloseableIterator<V> getIterator(long timeout, TimeUnit timeUnit) throws BlueDbException;
 
 	/**
 	 * Executes the query and returns the number of values matching the query

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/CollectionValueIterator.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/CollectionValueIterator.java
@@ -42,8 +42,13 @@ public class CollectionValueIterator<T extends Serializable> implements Closeabl
 		if (hasClosed.get()) {
 			throw new RuntimeException("CollectionValueIterator has already been closed");
 		}
-		timeoutCloser.snooze();
-		return entityIterator.hasNext();
+		
+		try {
+			timeoutCloser.setToWaitingOnBlueDb();
+			return entityIterator.hasNext();
+		} finally {
+			timeoutCloser.setToWaitingOnClient();
+		}
 	}
 
 	@Override
@@ -51,12 +56,17 @@ public class CollectionValueIterator<T extends Serializable> implements Closeabl
 		if (hasClosed.get()) {
 			throw new RuntimeException("CollectionValueIterator has already been closed");
 		}
-		timeoutCloser.snooze();
-		BlueEntity<T> peekedEntity = entityIterator.peek();
-		if (peekedEntity == null) {
-			return null;
-		} else {
-			return peekedEntity.getValue();
+		
+		try {
+			timeoutCloser.setToWaitingOnBlueDb();
+			BlueEntity<T> peekedEntity = entityIterator.peek();
+			if (peekedEntity == null) {
+				return null;
+			} else {
+				return peekedEntity.getValue();
+			}
+		} finally {
+			timeoutCloser.setToWaitingOnClient();
 		}
 	}
 
@@ -65,8 +75,13 @@ public class CollectionValueIterator<T extends Serializable> implements Closeabl
 		if (hasClosed.get()) {
 			throw new RuntimeException("CollectionValueIterator has already been closed");
 		}
-		timeoutCloser.snooze();
-		return entityIterator.next().getValue();
+		
+		try {
+			timeoutCloser.setToWaitingOnBlueDb();
+			return entityIterator.next().getValue();
+		} finally {
+			timeoutCloser.setToWaitingOnClient();
+		}
 	}
 	
 	@Override

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/query/ReadOnlyQueryOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/query/ReadOnlyQueryOnDisk.java
@@ -3,6 +3,7 @@ package org.bluedb.disk.query;
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.bluedb.api.CloseableIterator;
 import org.bluedb.api.Condition;
@@ -43,6 +44,13 @@ public class ReadOnlyQueryOnDisk<T extends Serializable> implements ReadBlueQuer
 	public CloseableIterator<T> getIterator() throws BlueDbException {
 		Range range = new Range(min, max);
 		return new CollectionValueIterator<T>(collection.getSegmentManager(), range, byStartTime, objectConditions);
+	}
+
+	@Override
+	public CloseableIterator<T> getIterator(long timeout, TimeUnit timeUnit) throws BlueDbException {
+		Range range = new Range(min, max);
+		long timeoutInMillis = TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
+		return new CollectionValueIterator<T>(collection.getSegmentManager(), range, timeoutInMillis, byStartTime, objectConditions);
 	}
 
 	@Override

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadableDbOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadableDbOnDiskTest.java
@@ -585,6 +585,25 @@ public class ReadableDbOnDiskTest extends BlueDbDiskTestBase {
         assertEquals(1, onlyBob.size());
         assertFalse(onlyBob.contains(valueJoe));
         assertTrue(onlyBob.contains(valueBob));
+
+        final Iterator<TestValue> autoCloseFastIterator = getTimeCollection().query().where((v) -> v.getName().equals("Bob")).getIterator(10, TimeUnit.MILLISECONDS);
+        Blutils.trySleep(15);
+        TestTask useIteratorAfterAutoClosedTask = new TestTask(() -> {
+        	autoCloseFastIterator.hasNext();
+        });
+        useIteratorAfterAutoClosedTask.run();
+        TestUtils.assertThrowable(RuntimeException.class, useIteratorAfterAutoClosedTask.getError());
+        
+        final Iterator<TestValue> autoCloseAfterOneSecondIterator = getTimeCollection().query().getIterator(1, TimeUnit.SECONDS);
+        assertTrue(autoCloseAfterOneSecondIterator.hasNext());
+        Blutils.trySleep(750);
+        assertTrue(autoCloseAfterOneSecondIterator.hasNext());
+        Blutils.trySleep(1500);
+        useIteratorAfterAutoClosedTask = new TestTask(() -> {
+        	autoCloseAfterOneSecondIterator.hasNext();
+        });
+        useIteratorAfterAutoClosedTask.run();
+        TestUtils.assertThrowable(RuntimeException.class, useIteratorAfterAutoClosedTask.getError());
 	}
 	
 	@Test

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/lock/AutoCloseCountdownTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/lock/AutoCloseCountdownTest.java
@@ -34,6 +34,14 @@ public class AutoCloseCountdownTest {
 		assertTrue(successfullyCloses(closeable, 2000));
 
 		closeable = new TestingCloseable(); 
+		countdown = new AutoCloseCountdown(closeable, 50);
+		countdown.setToWaitingOnBlueDb();
+		assertFalse(successfullyCloses(closeable, 200));
+		countdown.setToWaitingOnClient();
+		assertTrue(countdown.remainingTime() > 15);
+		assertTrue(successfullyCloses(closeable, 2000));
+
+		closeable = new TestingCloseable(); 
 		new AutoCloseCountdown(closeable, 3000);
 		assertFalse(successfullyCloses(closeable, 100));
 	}


### PR DESCRIPTION
- A query iterator can no longer timeout while bluedb is working on the query. It can only timeout when bluedb is waiting on the client code to continue iterating. The timeout is reset when we start waiting on the client code rather than when the client invokes an operation.
- Client code can now specify a custom timeout for query iterators instead of having to use the default 15 seconds.