### PR TITLE
Fix large collection validation

### DIFF
--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/validation/ObjectValidation.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/serialization/validation/ObjectValidation.java
@@ -24,6 +24,8 @@ public class ObjectValidation {
 			return;
 		}
 		
+		previouslyValidatedObjects.add(obj);
+		
 		if(obj.getClass().isArray()) {
 			handleArray(obj, previouslyValidatedObjects);
 		} else if(obj instanceof Iterable) { 
@@ -39,7 +41,6 @@ public class ObjectValidation {
 		for(int i = 0; i < Array.getLength(objArray); i++) {
 			Object obj = Array.get(objArray, i);
 			if(obj != null && !previouslyValidatedObjects.contains(obj)) {
-				previouslyValidatedObjects.add(obj);
 				validateFieldValueTypesForObject(obj, previouslyValidatedObjects);
 			}
 		}
@@ -50,7 +51,6 @@ public class ObjectValidation {
 		while(it.hasNext()) {
 			Object obj = it.next();
 			if(obj != null && !previouslyValidatedObjects.contains(obj)) {
-				previouslyValidatedObjects.add(obj);
 				validateFieldValueTypesForObject(obj, previouslyValidatedObjects);
 			}
 		}
@@ -63,11 +63,9 @@ public class ObjectValidation {
 			Entry<?, ?> entry = (Entry<?, ?>) it.next();
 			if(entry != null) {
 				if(entry.getKey() != null && !previouslyValidatedObjects.contains(entry.getKey())) {
-					previouslyValidatedObjects.add(entry.getKey());
 					validateFieldValueTypesForObject(entry.getKey(), previouslyValidatedObjects);
 				}
 				if(entry.getValue() != null && !previouslyValidatedObjects.contains(entry.getValue())) {
-					previouslyValidatedObjects.add(entry.getValue());
 					validateFieldValueTypesForObject(entry.getValue(), previouslyValidatedObjects);
 				}
 			}
@@ -88,7 +86,6 @@ public class ObjectValidation {
 							validateFieldValueType(field, fieldValue);
 							
 							if(delveIntoObjects && shouldDelveIntoObject(field, fieldValue, previouslyValidatedObjects)) {
-								previouslyValidatedObjects.add(fieldValue);
 								validateFieldValueTypesForObject(fieldValue, previouslyValidatedObjects);
 							}
 						}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/serialization/validation/ObjectValidationTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/serialization/validation/ObjectValidationTest.java
@@ -11,13 +11,16 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 
 import org.bluedb.TestUtils;
 import org.bluedb.disk.TestValue;
 import org.bluedb.disk.models.calls.Call;
+import org.bluedb.disk.models.calls.CallV2;
 import org.bluedb.disk.serialization.BlueSerializer;
 import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
 import org.junit.Assert;
@@ -133,6 +136,33 @@ public class ObjectValidationTest {
 			e.printStackTrace();
 			fail();
 		}
+	}
+	
+	@Test
+	public void testMassiveArrayOfValidCalls() throws IllegalArgumentException, IllegalAccessException, SerializationException {
+		CallV2[] calls = new CallV2[100000];
+		for(int i = 0; i < 100000; i++) {
+			calls[i] = CallV2.generateBasicTestCall();
+		}
+		ObjectValidation.validateFieldValueTypesForObject(calls);
+	}
+	
+	@Test
+	public void testMassiveIterableOfValidCalls() throws IllegalArgumentException, IllegalAccessException, SerializationException {
+		List<CallV2> calls = new LinkedList<>();
+		for(int i = 0; i < 100000; i++) {
+			calls.add(CallV2.generateBasicTestCall());
+		}
+		ObjectValidation.validateFieldValueTypesForObject(calls);
+	}
+	
+	@Test
+	public void testMassiveMapOfValidCalls() throws IllegalArgumentException, IllegalAccessException, SerializationException {
+		Map<UUID, CallV2> calls = new HashMap<>();
+		for(int i = 0; i < 100000; i++) {
+			calls.put(UUID.randomUUID(), CallV2.generateBasicTestCall());
+		}
+		ObjectValidation.validateFieldValueTypesForObject(calls);
 	}
 
 	@Test

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'java'
-version = '2.1.6'
+version = '2.1.7'
 
 subprojects {
     apply plugin: 'java'


### PR DESCRIPTION
Attempting to serialize a large linked list would result in a stack overflow since our object validation reflectively validates each field in the object being serialized. Sine each node has a reference to the next node it was validating the entire list via recursion in a single stack. Now Iterable and Map objects have special handling to avoid this type of issue by validating each individual item in the collection.