### PR TITLE
File exists optimization

### DIFF
--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/file/FileUtils.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/file/FileUtils.java
@@ -87,6 +87,13 @@ public class FileUtils {
 		String fileName = file.getName();
 		return fileName.startsWith(TEMP_FILE_PREFIX);
 	}
+	
+	public static boolean exists(Path path) {
+		if(path == null) {
+			return false;
+		}
+		return path.toFile().exists();
+	}
 
 	public static void moveFile(Path src, BlueWriteLock<Path> lock) throws BlueDbException {
 		Path dst = lock.getKey();

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/segment/ReadableSegment.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/segment/ReadableSegment.java
@@ -2,7 +2,6 @@ package org.bluedb.disk.segment;
 
 import java.io.File;
 import java.io.Serializable;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -103,13 +102,13 @@ public abstract class ReadableSegment <T extends Serializable> implements Compar
 	public Path getPathFor(long groupingNumber) throws BlueDbException {
 		for (long rollupLevel: rollupLevels) {
 			Path path = getPathFor(groupingNumber, rollupLevel);
-			if(Files.exists(path)) {
+			if(FileUtils.exists(path)) {
 				return path;
 			}
 		}
 		if (groupingNumber < segmentRange.getStart()) {
 			Path path = getPathFor(preSegmentRange);
-			if(Files.exists(path)) {
+			if(FileUtils.exists(path)) {
 				return path;
 			}
 		}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadOnlyDbOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadOnlyDbOnDiskTest.java
@@ -27,6 +27,7 @@ import org.bluedb.disk.collection.ReadOnlyCollectionOnDisk;
 import org.bluedb.disk.collection.ReadWriteTimeCollectionOnDisk;
 import org.bluedb.disk.collection.index.TestMultiRetrievalKeyExtractor;
 import org.bluedb.disk.collection.index.TestRetrievalKeyExtractor;
+import org.bluedb.disk.file.FileUtils;
 import org.bluedb.disk.recovery.PendingChange;
 import org.bluedb.disk.serialization.BlueSerializer;
 import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
@@ -100,7 +101,7 @@ public class ReadOnlyDbOnDiskTest extends BlueDbDiskTestBase {
 		assertNotNull(collection);
 		assertEquals(collection, readOnlyDb.getCollection(getTimeCollectionName(), TestValue.class));
 		assertNull(db.getCollection("non-existing", TestValue.class));
-		assertFalse(Files.exists(segmentSizePath));
+		assertFalse(FileUtils.exists(segmentSizePath));
 	}
 
 	@Test

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadableDbOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadableDbOnDiskTest.java
@@ -27,6 +27,7 @@ import org.bluedb.api.keys.TimeKey;
 import org.bluedb.disk.collection.ReadWriteCollectionOnDisk;
 import org.bluedb.disk.collection.ReadWriteTimeCollectionOnDisk;
 import org.bluedb.disk.collection.metadata.ReadWriteCollectionMetaData;
+import org.bluedb.disk.file.FileUtils;
 import org.bluedb.disk.file.ReadWriteFileManager;
 import org.bluedb.disk.recovery.IndividualChange;
 import org.bluedb.disk.recovery.PendingBatchChange;
@@ -83,7 +84,7 @@ public class ReadableDbOnDiskTest extends BlueDbDiskTestBase {
 		
 		ReadWriteDbOnDisk newDb = (ReadWriteDbOnDisk) (new BlueDbOnDiskBuilder()).withPath(db.getPath()).build();
 		newDb.getTimeCollectionBuilder(getTimeCollectionName(), TimeKey.class, TestValue.class).build();
-		assertTrue(Files.exists(segmentSizePath));
+		assertTrue(FileUtils.exists(segmentSizePath));
 	}
 
 	@Test

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/LegacyCollectionSupportTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/LegacyCollectionSupportTest.java
@@ -21,7 +21,6 @@ import org.bluedb.api.keys.StringKey;
 import org.bluedb.api.keys.TimeFrameKey;
 import org.bluedb.api.keys.TimeKey;
 import org.bluedb.api.keys.UUIDKey;
-import org.bluedb.disk.ReadWriteDbOnDisk;
 import org.bluedb.disk.BlueDbOnDiskBuilder;
 import org.bluedb.disk.Blutils;
 import org.bluedb.disk.IndexableTestValue;
@@ -29,7 +28,9 @@ import org.bluedb.disk.IndexableTestValue.IndexableTestValueIntIndexExtractor;
 import org.bluedb.disk.IndexableTestValue.IndexableTestValueLongIndexExtractor;
 import org.bluedb.disk.IndexableTestValue.IndexableTestValueStringIndexExtractor;
 import org.bluedb.disk.IndexableTestValue.IndexableTestValueUUIDIndexExtractor;
+import org.bluedb.disk.ReadWriteDbOnDisk;
 import org.bluedb.disk.collection.index.ReadWriteIndexOnDisk;
+import org.bluedb.disk.file.FileUtils;
 import org.bluedb.disk.segment.SegmentSizeSetting;
 import org.bluedb.zip.ZipUtils;
 import org.junit.Test;
@@ -89,7 +90,7 @@ public class LegacyCollectionSupportTest extends TestCase {
 		tmpDirPath = createTempFolder().toPath();
 		dbPath = tmpDirPath.resolve(DB_NAME);
 		
-		if(Files.exists(backupPath)) {
+		if(FileUtils.exists(backupPath)) {
 			ZipUtils.extractFiles(backupPath, tmpDirPath);
 		}
 		
@@ -141,7 +142,7 @@ public class LegacyCollectionSupportTest extends TestCase {
 		allValuesToTest = new ArrayList<>(existingValuesToTest);
 		allValuesToTest.addAll(newValuesToTest);
 		
-		if(!Files.exists(backupPath)) {
+		if(!FileUtils.exists(backupPath)) {
 			insertValues(existingValuesToTest);
 			createBackup();
 		}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/FileUtilsTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/FileUtilsTest.java
@@ -132,6 +132,14 @@ public class FileUtilsTest extends TestCase {
 			FileUtils.ensureDirectoryExists(targetFilePath.toFile()); // make sure a second one doesn't error out
 		}
 	}
+	
+	@Test
+	public void test_exists() throws BlueDbException {
+		assertFalse(FileUtils.exists(null));
+		assertFalse(FileUtils.exists(testPath));
+		FileUtils.ensureFileExists(testPath);
+		assertTrue(FileUtils.exists(testPath));
+	}
 
 	@Test
 	public void test_createTempFilePath() {
@@ -278,7 +286,7 @@ public class FileUtilsTest extends TestCase {
 	public void test_deleteIfExistsWithoutLock() throws IOException {
 		Path tempFile = Files.createTempFile("FileUtilsTest-test_deleteIfExistsWithoutLock1", ".bin");
 		tempFile.toFile().deleteOnExit();
-		assertTrue(Files.exists(tempFile));
+		assertTrue(FileUtils.exists(tempFile));
 		
 		tempFile.toFile().setReadOnly(); //Makes it so that a delete will fail
 		try {
@@ -287,7 +295,7 @@ public class FileUtilsTest extends TestCase {
 		} catch (BlueDbException e) {
 			//Expect it to fail
 		}
-		assertTrue(Files.exists(tempFile)); //File should still exist
+		assertTrue(FileUtils.exists(tempFile)); //File should still exist
 		
 		tempFile.toFile().setWritable(true); //Make it so that delete can succeed again
 		try {
@@ -295,7 +303,7 @@ public class FileUtilsTest extends TestCase {
 		} catch (BlueDbException e) {
 			fail(); //Should not throw exception
 		}
-		assertFalse(Files.exists(tempFile)); //File should be gone
+		assertFalse(FileUtils.exists(tempFile)); //File should be gone
 	}
 	
 	@Test

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/lock/FileTestUtility.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/lock/FileTestUtility.java
@@ -9,6 +9,8 @@ import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Random;
 
+import org.bluedb.disk.file.FileUtils;
+
 public class FileTestUtility {
 	public static void main(String[] args) throws IOException {
 		String action = args[0];
@@ -43,7 +45,7 @@ public class FileTestUtility {
 		byte[] bytes = new byte[(int)testFileSize]; 
 		new Random().nextBytes(bytes);
 		Files.write(testFile, bytes);
-		boolean success = Files.exists(testFile) && Files.size(testFile) == testFileSize;
+		boolean success = FileUtils.exists(testFile) && Files.size(testFile) == testFileSize;
 		System.out.println("Create Complete [success]" + success);
 	}
 
@@ -65,7 +67,7 @@ public class FileTestUtility {
 	private static void deleteTestFile(Path testFile) throws IOException {
 		System.out.println("Deleting test file " + testFile);
 		Files.delete(testFile);
-		boolean success = !Files.exists(testFile);
+		boolean success = !FileUtils.exists(testFile);
 		System.out.println("Delete Complete [success]" + success);
 	}
 

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/segment/SegmentSizeSettingsTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/segment/SegmentSizeSettingsTest.java
@@ -39,6 +39,7 @@ import org.bluedb.api.keys.StringKey;
 import org.bluedb.api.keys.TimeFrameKey;
 import org.bluedb.api.keys.TimeKey;
 import org.bluedb.api.keys.UUIDKey;
+import org.bluedb.disk.file.FileUtils;
 import org.bluedb.disk.segment.path.SegmentSizeConfiguration;
 import org.bluedb.disk.serialization.BlueSerializer;
 import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
@@ -209,7 +210,7 @@ public class SegmentSizeSettingsTest {
 		List<SegmentSizeSetting> allValuesInCodeInAlphabeticalOrder = Arrays.asList(SegmentSizeSetting.values());
 		Collections.sort(allValuesInCodeInAlphabeticalOrder, Comparator.comparing(SegmentSizeSetting::name));
 		
-		if(Files.exists(serializedSettingsPath)) {
+		if(FileUtils.exists(serializedSettingsPath)) {
 			@SuppressWarnings("unchecked")
 			List<SegmentSizeSetting> allSerializedValues = (List<SegmentSizeSetting>) serializer.deserializeObjectFromByteArray(Files.readAllBytes(serializedSettingsPath));
 			


### PR DESCRIPTION
Added new FileUtils method for checking if a file for a given path
exists. The Files.exists method is apparently not very performant when
the file doesn't exist. This change should optimize bluedb a bit and
take some load off of the garbage collector. There were tons of
exceptions being thrown, caught, and garbage collected.