### PR TITLE
Xima 9704

### DIFF
--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/file/FileUtils.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/file/FileUtils.java
@@ -48,11 +48,19 @@ public class FileUtils {
 		return getFolderContentsExcludingTempFiles(path.toFile(), endsWithSuffix);
 	}
 
-	public static List<File> getFolderContentsExcludingTempFiles(File folder, FileFilter filter) {
+	public static DirectoryStream<Path> getFolderContentsExcludingTempFilesAsStream(Path path, String suffix) throws IOException {
+		FileFilter endsWithSuffix = (f) -> f.toPath().toString().endsWith(suffix);
+		return getFolderContentsExcludingTempFilesAsStream(path.toFile(), endsWithSuffix);
+	}
+
+	private static DirectoryStream<Path> getFolderContentsExcludingTempFilesAsStream(File folder, FileFilter filter) throws IOException {
 		Filter<Path> passesFilterAndIsNotTempFile = (p) -> filter.accept(p.toFile()) && IS_NOT_TEMP_FILE.accept(p.toFile());
-		
+		return Files.newDirectoryStream(Paths.get(folder.getAbsolutePath()), passesFilterAndIsNotTempFile );
+	}
+
+	public static List<File> getFolderContentsExcludingTempFiles(File folder, FileFilter filter) {
 		List<File> files = new LinkedList<File>();
-		try(DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(folder.getAbsolutePath()), passesFilterAndIsNotTempFile )){
+		try(DirectoryStream<Path> stream = getFolderContentsExcludingTempFilesAsStream(folder, filter)){
 			stream.iterator().forEachRemaining(p -> files.add(p.toFile()));
 		} catch (IOException ex) {
 			ex.printStackTrace();

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/file/FileUtils.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/file/FileUtils.java
@@ -53,20 +53,20 @@ public class FileUtils {
 		return getFolderContentsExcludingTempFilesAsStream(path.toFile(), endsWithSuffix);
 	}
 
-	private static DirectoryStream<Path> getFolderContentsExcludingTempFilesAsStream(File folder, FileFilter filter) throws IOException {
-		Filter<Path> passesFilterAndIsNotTempFile = (p) -> filter.accept(p.toFile()) && IS_NOT_TEMP_FILE.accept(p.toFile());
-		return Files.newDirectoryStream(Paths.get(folder.getAbsolutePath()), passesFilterAndIsNotTempFile );
-	}
-
 	public static List<File> getFolderContentsExcludingTempFiles(File folder, FileFilter filter) {
 		List<File> files = new LinkedList<File>();
 		try(DirectoryStream<Path> stream = getFolderContentsExcludingTempFilesAsStream(folder, filter)){
 			stream.iterator().forEachRemaining(p -> files.add(p.toFile()));
 		} catch (IOException ex) {
-			ex.printStackTrace();
+			
 		}
 		
 		return files;
+	}
+	
+	private static DirectoryStream<Path> getFolderContentsExcludingTempFilesAsStream(File folder, FileFilter filter) throws IOException {
+		Filter<Path> passesFilterAndIsNotTempFile = (p) -> filter.accept(p.toFile()) && IS_NOT_TEMP_FILE.accept(p.toFile());
+		return Files.newDirectoryStream(Paths.get(folder.getAbsolutePath()), passesFilterAndIsNotTempFile );
 	}
 
 	public static void ensureFileExists(Path path) throws BlueDbException {

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/ChangeHistoryCleaner.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/ChangeHistoryCleaner.java
@@ -1,8 +1,13 @@
 package org.bluedb.disk.recovery;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -12,7 +17,9 @@ import org.bluedb.disk.Blutils;
 public class ChangeHistoryCleaner {
 
 	private static int DEFAULT_RETENTION_LIMIT = 200;
+	private static int DEFAULT_BATCH_REMOVAL_LIMIT = 10000;
 	private int completedChangeLimit = DEFAULT_RETENTION_LIMIT;
+	private int completedChangeBatchRemovalLimit = DEFAULT_BATCH_REMOVAL_LIMIT;
 	private final AtomicInteger holdsOnHistoryCleanup = new AtomicInteger(0);
 	private long waitBetweenCleanups = 5_000;
 	final Path historyFolderPath;
@@ -48,11 +55,29 @@ public class ChangeHistoryCleaner {
 		if (holdsOnHistoryCleanup.get() > 0) {
 			return;
 		}
-		List<TimeStampedFile> timestampedFiles = getCompletedTimeStampedFiles();
-		Collections.sort(timestampedFiles);
-		int numFilesToDelete = Math.max(0, timestampedFiles.size() - completedChangeLimit);
-		List<TimeStampedFile> filesToDelete = timestampedFiles.subList(0, numFilesToDelete);
-		filesToDelete.forEach((f) -> f.getFile().delete());
+		try (DirectoryStream<Path> completedChangeFileStream = recoveryManager.getCompletedChangeFilesAsStream()){
+			Iterator<Path> iterator = completedChangeFileStream.iterator();
+			List<TimeStampedFile> timestampedFiles = new LinkedList<TimeStampedFile>();
+			while (iterator.hasNext()) {
+				timestampedFiles.addAll(getNextBatchOfTimestampedFiles(iterator));
+				Collections.sort(timestampedFiles);
+				int numFilesToDelete = Math.max(0, timestampedFiles.size() - completedChangeLimit);
+				List<TimeStampedFile> filesToDelete = timestampedFiles.subList(0, numFilesToDelete);
+				filesToDelete.forEach((f) -> f.getFile().delete());
+			}
+		} catch (IOException ex) {
+			
+		}
+	}
+
+	private Collection<TimeStampedFile> getNextBatchOfTimestampedFiles(Iterator<Path> iterator) {
+		List<File> historicChangeFiles = new LinkedList<>();
+		while (iterator.hasNext() && historicChangeFiles.size() < completedChangeBatchRemovalLimit) {
+			Path next = iterator.next();
+			historicChangeFiles.add(next.toFile());
+		}
+		List<TimeStampedFile> timestampedFiles = Blutils.mapIgnoringExceptions(historicChangeFiles, (f) -> new TimeStampedFile(f) );
+		return timestampedFiles;
 	}
 
 	public void setWaitBetweenCleanups(long millis) {

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/ChangeHistoryCleaner.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/ChangeHistoryCleaner.java
@@ -61,8 +61,11 @@ public class ChangeHistoryCleaner {
 			while (iterator.hasNext()) {
 				timestampedFiles.addAll(getNextBatchOfTimestampedFiles(iterator));
 				Collections.sort(timestampedFiles);
+				
 				int numFilesToDelete = Math.max(0, timestampedFiles.size() - completedChangeLimit);
 				List<TimeStampedFile> filesToDelete = timestampedFiles.subList(0, numFilesToDelete);
+				timestampedFiles.removeAll(filesToDelete);
+
 				filesToDelete.forEach((f) -> f.getFile().delete());
 			}
 		} catch (IOException ex) {

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/RecoveryManager.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/RecoveryManager.java
@@ -106,10 +106,6 @@ public class RecoveryManager<T extends Serializable> {
 		return changes;
 	}
 
-	public List<File> getCompletedChangeFiles() {
-		return FileUtils.getFolderContentsExcludingTempFiles(historyFolderPath, SUFFIX_COMPLETE);
-	}
-
 	public DirectoryStream<Path> getCompletedChangeFilesAsStream() throws IOException {
 		return FileUtils.getFolderContentsExcludingTempFilesAsStream(historyFolderPath, SUFFIX_COMPLETE);
 	}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/RecoveryManager.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/recovery/RecoveryManager.java
@@ -1,7 +1,9 @@
 package org.bluedb.disk.recovery;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -106,6 +108,10 @@ public class RecoveryManager<T extends Serializable> {
 
 	public List<File> getCompletedChangeFiles() {
 		return FileUtils.getFolderContentsExcludingTempFiles(historyFolderPath, SUFFIX_COMPLETE);
+	}
+
+	public DirectoryStream<Path> getCompletedChangeFilesAsStream() throws IOException {
+		return FileUtils.getFolderContentsExcludingTempFilesAsStream(historyFolderPath, SUFFIX_COMPLETE);
 	}
 
 	public List<File> getPendingChangeFiles() {

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/FileUtilsTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/FileUtilsTest.java
@@ -74,9 +74,26 @@ public class FileUtilsTest extends TestCase {
 		createFile(nonEmptyFolder, "junk");
 		List<File> filesWithSuffix = FileUtils.getFolderContentsExcludingTempFiles(nonEmptyFolder.toPath(), suffix);
 		assertEquals(2, filesWithSuffix.size());
-		assertTrue(filesWithSuffix.contains(fileWithSuffix));
-		assertTrue(filesWithSuffix.contains(fileWithSuffix2));
-		assertFalse(filesWithSuffix.contains(tempFile));
+		assertListContainsFile(filesWithSuffix, fileWithSuffix);
+		assertListContainsFile(filesWithSuffix, fileWithSuffix2);
+		assertListDoesNotContainFile(filesWithSuffix,tempFile);
+	}
+	
+	private void assertListContainsFile(List<File> filteredResult, File fileInQuestion) {
+		assertTrue("List did not contain file name: " + fileInQuestion.toString(), listContainsFile(filteredResult, fileInQuestion));
+	}
+
+	private void assertListDoesNotContainFile(List<File> filteredResult, File fileInQuestion) {
+		assertTrue("List did contain file name: " + fileInQuestion.toString(), !listContainsFile(filteredResult, fileInQuestion));
+	}
+
+	private boolean listContainsFile(List<File> filteredResult, File fileInQuestion) {
+		for (File file : filteredResult) {
+			if (file.toString().endsWith(fileInQuestion.toString())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Test

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/recovery/RecoveryManagerTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/recovery/RecoveryManagerTest.java
@@ -5,6 +5,7 @@ import java.io.FileOutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import org.junit.Test;
 
@@ -126,8 +127,9 @@ public class RecoveryManagerTest extends BlueDbDiskTestBase {
 		getRecoveryManager().markComplete(change);
 		changes = getRecoveryManager().getPendingChangeFiles();
 		assertEquals(0, changes.size());
-
-		List<File> completedChanges = getRecoveryManager().getCompletedChangeFiles();
+		
+		List<File> completedChanges = new LinkedList<File>();
+		getRecoveryManager().getCompletedChangeFilesAsStream().iterator().forEachRemaining((p) -> completedChanges.add(p.toFile()));
 		assertEquals(1, completedChanges.size());
 
 		File completedChangeFile = completedChanges.get(0);
@@ -135,7 +137,8 @@ public class RecoveryManagerTest extends BlueDbDiskTestBase {
 		tempCompletedFile.createNewFile();
 		allFilesInChangeFolder = Arrays.asList(historyFolderPath.toFile().listFiles());
 		assertEquals(3, allFilesInChangeFolder.size());  // [pending change temp file, complete change temp file, complete change file]
-		completedChanges = getRecoveryManager().getCompletedChangeFiles();
+		completedChanges.clear();
+		getRecoveryManager().getCompletedChangeFilesAsStream().iterator().forEachRemaining((p) -> completedChanges.add(p.toFile()));
 		assertEquals(1, completedChanges.size());
 	}
 


### PR DESCRIPTION
We were experiencing issues where the recovery folders were growing too large and loading the contents of the entire folder resulted in OOM errors. We now use a `DirectoryStream` to reduce memory usage