### PR TITLE
Made object validation configurable

### DIFF
--- a/BlueDBIntegrationE2ETests/src/test/java/org/bluedb/disk/helpers/BlueDbOnDiskWrapper.java
+++ b/BlueDBIntegrationE2ETests/src/test/java/org/bluedb/disk/helpers/BlueDbOnDiskWrapper.java
@@ -1,5 +1,9 @@
 package org.bluedb.disk.helpers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+
 import org.bluedb.api.exceptions.BlueDbException;
 import org.bluedb.api.keys.BlueKey;
 import org.bluedb.api.keys.HashGroupedKey;
@@ -28,6 +33,7 @@ import org.bluedb.disk.ReadWriteDbOnDisk;
 import org.bluedb.disk.TestValue;
 import org.bluedb.disk.collection.ReadWriteCollectionOnDisk;
 import org.bluedb.disk.collection.ReadWriteTimeCollectionOnDisk;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.collection.metadata.ReadWriteCollectionMetaData;
 import org.bluedb.disk.lock.LockManager;
 import org.bluedb.disk.models.calls.Call;
@@ -35,9 +41,7 @@ import org.bluedb.disk.segment.ReadWriteSegment;
 import org.bluedb.disk.segment.SegmentEntityIterator;
 import org.bluedb.disk.segment.rollup.RollupScheduler;
 import org.bluedb.disk.serialization.BlueEntity;
-import static org.junit.Assert.*;
 
-@SuppressWarnings({"ResultOfMethodCallIgnored", "unused"})
 public class BlueDbOnDiskWrapper implements Closeable {
 
 	private static final String TIME_COLLECTION_NAME = "testing_time";
@@ -65,11 +69,19 @@ public class BlueDbOnDiskWrapper implements Closeable {
 
 		switch (startupOption) {
 			case EncryptionEnabled:
-				db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder().withPath(dbPath).withEncryptionService(encryptionService).build();
+				db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder()
+					.withPath(dbPath)
+					.withConfigurationService(new TestDefaultConfigurationService())
+					.withEncryptionService(encryptionService)
+					.build();
 				break;
 			case EncryptionDisabled:
 				encryptionService.setEncryptionEnabled(false);
-				db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder().withPath(dbPath).withEncryptionService(encryptionService).build();
+				db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder()
+						.withPath(dbPath)
+						.withConfigurationService(new TestDefaultConfigurationService())
+						.withEncryptionService(encryptionService)
+						.build();
 				break;
 			default:
 				throw new IllegalStateException("Unexpected value: " + startupOption);
@@ -90,11 +102,19 @@ public class BlueDbOnDiskWrapper implements Closeable {
 
 		switch (startupOption) {
 			case EncryptionEnabled:
-				db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder().withPath(dbPath).withEncryptionService(encryptionService).build();
+				db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder()
+					.withPath(dbPath)
+					.withConfigurationService(new TestDefaultConfigurationService())
+					.withEncryptionService(encryptionService)
+					.build();
 				break;
 			case EncryptionDisabled:
 				encryptionService.setEncryptionEnabled(false);
-				db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder().withPath(dbPath).withEncryptionService(encryptionService).build();
+				db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder()
+						.withPath(dbPath)
+						.withConfigurationService(new TestDefaultConfigurationService())
+						.withEncryptionService(encryptionService)
+						.build();
 				break;
 			default:
 				throw new IllegalStateException("Unexpected value: " + startupOption);

--- a/BlueDBOnDisk/build.gradle
+++ b/BlueDBOnDisk/build.gradle
@@ -8,7 +8,8 @@ repositories {
 
 dependencies{
 	implementation project(':BlueDB')
-    implementation group: 'de.ruedigermoeller', name: 'fst', version: '2.57'
+	
+    implementation 'com.github.d-w-johnson:fast-serialization:v2.59'
     testImplementation group: 'org.mockito', name: 'mockito-all', version: mockitoVersion
     testImplementation "junit:junit:4.12"
 }

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/BlueDbOnDiskBuilder.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/BlueDbOnDiskBuilder.java
@@ -5,6 +5,8 @@ import java.nio.file.Paths;
 
 import org.bluedb.api.BlueDb;
 import org.bluedb.api.ReadableBlueDb;
+import org.bluedb.disk.config.ConfigurationService;
+import org.bluedb.disk.config.DefaultConfigurationService;
 import org.bluedb.disk.encryption.EncryptionService;
 import org.bluedb.disk.encryption.EncryptionUtils;
 
@@ -13,6 +15,7 @@ import org.bluedb.disk.encryption.EncryptionUtils;
  */
 public class BlueDbOnDiskBuilder {
 	private Path path = Paths.get(".", "bluedb");
+	private ConfigurationService configurationService = new DefaultConfigurationService();
 	private EncryptionService encryptionService = null;
 
 	/**
@@ -22,6 +25,14 @@ public class BlueDbOnDiskBuilder {
 	 */
 	public BlueDbOnDiskBuilder withPath(Path path) {
 		this.path = path;
+		return this;
+	}
+
+	public BlueDbOnDiskBuilder withConfigurationService(ConfigurationService configurationService) {
+		if (configurationService == null) {
+			throw new IllegalArgumentException("configurationService cannot be null");
+		}
+		this.configurationService = configurationService;
 		return this;
 	}
 
@@ -45,13 +56,13 @@ public class BlueDbOnDiskBuilder {
 		this.encryptionService = encryptionService;
 		return this;
 	}
-
+	
 	/**
 	 * Builds the {@link BlueDb} object
 	 * @return the {@link BlueDb} built
 	 */
 	public BlueDb build() {
-		return new ReadWriteDbOnDisk(path, encryptionService);
+		return new ReadWriteDbOnDisk(path, configurationService, encryptionService);
 	}
 
 	/**
@@ -59,7 +70,7 @@ public class BlueDbOnDiskBuilder {
 	 * @return the {@link ReadableBlueDb} built
 	 */
 	public ReadableBlueDb buildReadOnly() {
-		return new ReadableDbOnDisk(path, encryptionService);
+		return new ReadableDbOnDisk(path, configurationService, encryptionService);
 	}
 	
 	/**

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/ReadWriteDbOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/ReadWriteDbOnDisk.java
@@ -21,12 +21,12 @@ import org.bluedb.disk.backup.BackupManager;
 import org.bluedb.disk.collection.ReadWriteCollectionOnDisk;
 import org.bluedb.disk.collection.ReadWriteTimeCollectionOnDisk;
 import org.bluedb.disk.collection.ReadableCollectionOnDisk;
+import org.bluedb.disk.config.ConfigurationService;
 import org.bluedb.disk.encryption.EncryptionService;
 import org.bluedb.disk.executors.BlueExecutor;
 import org.bluedb.disk.file.FileUtils;
 import org.bluedb.disk.segment.Range;
 import org.bluedb.disk.segment.SegmentSizeSetting;
-import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
 
 public class ReadWriteDbOnDisk extends ReadableDbOnDisk implements BlueDb {
 
@@ -35,8 +35,8 @@ public class ReadWriteDbOnDisk extends ReadableDbOnDisk implements BlueDb {
 	private final Map<String, ReadWriteCollectionOnDisk<? extends Serializable>> collections = new HashMap<>();
 
 
-	public ReadWriteDbOnDisk(Path path, EncryptionService encryptionService) {
-		super(path, encryptionService);
+	public ReadWriteDbOnDisk(Path path, ConfigurationService configurationService, EncryptionService encryptionService) {
+		super(path, configurationService, encryptionService);
 		this.backupManager = new BackupManager(this, this.encryptionService);
 		this.sharedExecutor = new BlueExecutor(path.getFileName().toString());
 	}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/ReadableDbOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/ReadableDbOnDisk.java
@@ -19,18 +19,23 @@ import org.bluedb.disk.collection.FacadeTimeCollection;
 import org.bluedb.disk.collection.NoSuchCollectionException;
 import org.bluedb.disk.collection.ReadOnlyCollectionOnDisk;
 import org.bluedb.disk.collection.ReadOnlyTimeCollectionOnDisk;
+import org.bluedb.disk.config.ConfigurationService;
+import org.bluedb.disk.config.ConfigurationServiceWrapper;
 import org.bluedb.disk.encryption.EncryptionService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
+import org.bluedb.disk.time.StandardTimeService;
 
 public class ReadableDbOnDisk implements ReadableBlueDb {
 
 	protected final Path path;
+	protected final ConfigurationServiceWrapper configurationService;
 	protected final EncryptionServiceWrapper encryptionService;
 
 	private final Map<String, ReadOnlyCollectionOnDisk<? extends Serializable>> collections = new HashMap<>();
 	
-	ReadableDbOnDisk(Path path, EncryptionService encryptionService) {
+	ReadableDbOnDisk(Path path, ConfigurationService configurationService, EncryptionService encryptionService) {
 		this.path = path;
+		this.configurationService = new ConfigurationServiceWrapper(configurationService, new StandardTimeService(), 60_000);
 		this.encryptionService = new EncryptionServiceWrapper(encryptionService);
 	}
 	
@@ -114,6 +119,8 @@ public class ReadableDbOnDisk implements ReadableBlueDb {
 	public Path getPath() {
 		return path;
 	}
+	
+	public ConfigurationServiceWrapper getConfigurationService() { return configurationService; }
 
 	public EncryptionServiceWrapper getEncryptionService() { return encryptionService; }
 

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadOnlyCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadOnlyCollectionOnDisk.java
@@ -38,7 +38,7 @@ public class ReadOnlyCollectionOnDisk<T extends Serializable> extends ReadableCo
 	@Override
 	protected ReadOnlyCollectionMetadata getOrCreateMetadata() {
 		if (metadata == null) {
-			metadata = new ReadOnlyCollectionMetadata(getPath(), this.encryptionService);
+			metadata = new ReadOnlyCollectionMetadata(getPath(), this.configurationService, this.encryptionService);
 		}
 		return metadata;
 	}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadWriteCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadWriteCollectionOnDisk.java
@@ -104,7 +104,9 @@ public class ReadWriteCollectionOnDisk<T extends Serializable> extends ReadableC
 	@Override
 	public void insert(BlueKey key, T value) throws BlueDbException {
 		ensureCorrectKeyType(key);
-		ObjectValidation.validateFieldValueTypesForObject(value);
+		if(configurationService.shouldValidateObjects()) {
+			ObjectValidation.validateFieldValueTypesForObject(value);
+		}
 		
 		KeyValueToChangeMapper<T> changeMapper = (originalKey, originalvalue) -> {
 			return IndividualChange.createInsertChange(key, value);
@@ -216,7 +218,7 @@ public class ReadWriteCollectionOnDisk<T extends Serializable> extends ReadableC
 	@Override
 	protected ReadWriteCollectionMetaData getOrCreateMetadata() {
 		if (metadata == null) {
-			metadata = new ReadWriteCollectionMetaData(getPath(), this.encryptionService);
+			metadata = new ReadWriteCollectionMetaData(getPath(), this.configurationService, this.encryptionService);
 		}
 		return metadata;
 	}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadableCollectionOnDisk.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/ReadableCollectionOnDisk.java
@@ -19,6 +19,7 @@ import org.bluedb.api.keys.ValueKey;
 import org.bluedb.disk.ReadableDbOnDisk;
 import org.bluedb.disk.collection.metadata.ReadWriteCollectionMetaData;
 import org.bluedb.disk.collection.metadata.ReadableCollectionMetadata;
+import org.bluedb.disk.config.ConfigurationService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.file.ReadFileManager;
 import org.bluedb.disk.query.ReadOnlyQueryOnDisk;
@@ -34,6 +35,7 @@ public abstract class ReadableCollectionOnDisk<T extends Serializable> implement
 
 	private final Class<T> valueType;
 	private final Class<? extends BlueKey> keyType;
+	protected final ConfigurationService configurationService;
 	protected final EncryptionServiceWrapper encryptionService;
 	protected final BlueSerializer serializer;
 	protected final Path collectionPath;
@@ -50,10 +52,11 @@ public abstract class ReadableCollectionOnDisk<T extends Serializable> implement
 		collectionPath = Paths.get(db.getPath().toString(), name);
 		boolean isNewCollection = !collectionPath.toFile().exists();
 		collectionPath.toFile().mkdirs();
+		configurationService = db.getConfigurationService();
 		encryptionService = db.getEncryptionService();
 		ReadableCollectionMetadata metaData = getOrCreateMetadata();
 		Class<? extends Serializable>[] classesToRegister = getClassesToRegister(additionalRegisteredClasses);
-		serializer = new ThreadLocalFstSerializer(classesToRegister);
+		serializer = new ThreadLocalFstSerializer(db.getConfigurationService(), classesToRegister);
 		keyType = determineKeyType(metaData, requestedKeyType);
 		segmentSizeSettings = determineSegmentSize(metaData, keyType, segmentSize, isNewCollection);
 	}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/metadata/ReadOnlyCollectionMetadata.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/metadata/ReadOnlyCollectionMetadata.java
@@ -2,6 +2,7 @@ package org.bluedb.disk.collection.metadata;
 
 import java.nio.file.Path;
 
+import org.bluedb.disk.config.ConfigurationService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.file.ReadOnlyFileManager;
 import org.bluedb.disk.serialization.BlueSerializer;
@@ -11,10 +12,10 @@ public class ReadOnlyCollectionMetadata extends ReadableCollectionMetadata {
 
 	ReadOnlyFileManager fileManager;
 
-	public ReadOnlyCollectionMetadata(Path collectionPath, EncryptionServiceWrapper encryptionService) {
+	public ReadOnlyCollectionMetadata(Path collectionPath, ConfigurationService configurationService, EncryptionServiceWrapper encryptionService) {
 		super(collectionPath);
 		// meta data needs its own serializer because collection doesn't know which classes to register until metadata deserializes them from disk
-		BlueSerializer serializer = new ThreadLocalFstSerializer();
+		BlueSerializer serializer = new ThreadLocalFstSerializer(configurationService);
 		fileManager = new ReadOnlyFileManager(serializer, encryptionService);  
 	}
 

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/metadata/ReadWriteCollectionMetaData.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/collection/metadata/ReadWriteCollectionMetaData.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import org.bluedb.api.exceptions.BlueDbException;
 import org.bluedb.api.keys.BlueKey;
+import org.bluedb.disk.config.ConfigurationService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.file.ReadWriteFileManager;
 import org.bluedb.disk.segment.SegmentSizeSetting;
@@ -19,10 +20,10 @@ public class ReadWriteCollectionMetaData extends ReadableCollectionMetadata {
 
 	final ReadWriteFileManager fileManager;
 
-	public ReadWriteCollectionMetaData(Path collectionPath, EncryptionServiceWrapper encryptionService) {
+	public ReadWriteCollectionMetaData(Path collectionPath, ConfigurationService configurationService, EncryptionServiceWrapper encryptionService) {
 		super(collectionPath);
 		// meta data needs its own serializer because collection doesn't know which classes to register until metadata deserializes them from disk
-		BlueSerializer serializer = new ThreadLocalFstSerializer();
+		BlueSerializer serializer = new ThreadLocalFstSerializer(configurationService);
 		fileManager = new ReadWriteFileManager(serializer, encryptionService);  
 	}
 

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/config/ConfigurationService.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/config/ConfigurationService.java
@@ -1,0 +1,28 @@
+package org.bluedb.disk.config;
+
+public interface ConfigurationService {
+	
+	/** 
+	 * This is how BlueDB will ask if it should validate objects before returning them in query results or persisting
+	 * them to disk. We introduced object validation as a work around in order to avoid causing errors and/or corrupt
+	 * BlueDB data when FST fails to convert bytes to an object correctly. Or potentially if BlueDB is given an object
+	 * that already has some sort of problem.
+	 * 
+	 * This method will be called often in case the answer changes so so don't take a long time in the implementation. 
+	 * However, BlueDB will limit how often it asks rather than asking before every single FST operation. The implementer
+	 * can choose whether to cache the value or look it up.
+	 * 
+	 * We think we've identified the issue and patched FST, but we want to proceed forward with caution. By default,
+	 * for now, object validation will be turned on. By supplying your own implementation of this service you can
+	 * turn it off in order to get performance benefits. We will be testing BlueDB without object validation
+	 * to ensure that there are no additional issues with FST. When we are confident then we plan on turning
+	 * off object validation by default.
+	 * 
+	 * @return false if BlueDB should not expend resources to verify objects are valid before reading or writing
+	 * to/from disk. This will be much faster, but it will assume objects given to it are valid and that FST
+	 * can be trusted not to make mistakes. If really old data from before object validation is persisted
+	 * in BlueDB, it could potentially have corrupt objects that can no longer be identified without object
+	 * validation.
+	 */
+	public boolean shouldValidateObjects();
+}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/config/ConfigurationServiceWrapper.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/config/ConfigurationServiceWrapper.java
@@ -1,0 +1,39 @@
+package org.bluedb.disk.config;
+
+import org.bluedb.disk.time.TimeService;
+
+public class ConfigurationServiceWrapper implements ConfigurationService {
+	
+	private final ConfigurationService service;
+	private final TimeService timeService;
+	private final long minTimeBetweenChecks;
+	
+	private boolean shouldValidateObjects;
+	
+	private long nextTimeToCheck = Long.MIN_VALUE;
+	
+	public ConfigurationServiceWrapper(ConfigurationService service, TimeService timeService, long minTimeBetweenChecks) {
+		this.service = service;
+		this.timeService = timeService;
+		this.minTimeBetweenChecks = minTimeBetweenChecks;
+	}
+
+	@Override
+	public synchronized boolean shouldValidateObjects() {
+		checkIfNecessary();
+		return shouldValidateObjects;
+	}
+
+	private void checkIfNecessary() {
+		long now = timeService.getCurrentTime();
+		if(now >= nextTimeToCheck) {
+			shouldValidateObjects = service.shouldValidateObjects();
+			nextTimeToCheck = now + minTimeBetweenChecks;
+		}
+	}
+	
+	public synchronized void resetNextTimeToCheck() {
+		nextTimeToCheck = Long.MIN_VALUE;
+	}
+
+}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/config/DefaultConfigurationService.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/config/DefaultConfigurationService.java
@@ -1,0 +1,10 @@
+package org.bluedb.disk.config;
+
+public class DefaultConfigurationService implements ConfigurationService {
+
+	@Override
+	public boolean shouldValidateObjects() {
+		return true; //By default we validate objects. A user has to turn it off until we have more confidence that it isn't needed.
+	}
+
+}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/time/StandardTimeService.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/time/StandardTimeService.java
@@ -1,0 +1,10 @@
+package org.bluedb.disk.time;
+
+public class StandardTimeService implements TimeService {
+
+	@Override
+	public long getCurrentTime() {
+		return System.currentTimeMillis();
+	}
+
+}

--- a/BlueDBOnDisk/src/main/java/org/bluedb/disk/time/TimeService.java
+++ b/BlueDBOnDisk/src/main/java/org/bluedb/disk/time/TimeService.java
@@ -1,0 +1,5 @@
+package org.bluedb.disk.time;
+
+public interface TimeService {
+	public long getCurrentTime();
+}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/TestUtils.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/TestUtils.java
@@ -16,9 +16,11 @@ import org.bluedb.api.keys.TimeKey;
 import org.bluedb.disk.IndexableTestValue;
 import org.bluedb.disk.collection.ReadWriteCollectionOnDisk;
 import org.bluedb.disk.collection.ReadWriteTimeCollectionOnDisk;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.models.calls.Call;
 import org.bluedb.disk.serialization.BlueEntity;
 import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
+import org.bluedb.disk.serialization.validation.SerializationException;
 
 public class TestUtils {
 	public static Path getResourcePath(String relativePath) throws URISyntaxException, IOException {
@@ -29,11 +31,11 @@ public class TestUtils {
 		return pathToStartFrom.resolve("src/test/resources").resolve(relativePath);
 	}
 
-	public static BlueEntity<Call> loadCorruptCall() throws URISyntaxException, IOException {
-		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+	public static BlueEntity<Call> loadCorruptCall() throws URISyntaxException, IOException, SerializationException {
+		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), Call.getClassesToRegister());
 		Path invalidObjectPath = TestUtils.getResourcePath("corruptCall-1.bin");
-		@SuppressWarnings({ "deprecation", "unchecked" })
-		BlueEntity<Call> invalidCall = (BlueEntity<Call>) serializer.deserializeObjectFromByteArrayWithoutChecks(Files.readAllBytes(invalidObjectPath));
+		@SuppressWarnings("unchecked")
+		BlueEntity<Call> invalidCall = (BlueEntity<Call>) serializer.deserializeObjectFromByteArray(Files.readAllBytes(invalidObjectPath));
 		return invalidCall;
 	}
 

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/BlueDbOnDiskBuilderTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/BlueDbOnDiskBuilderTest.java
@@ -1,13 +1,37 @@
 package org.bluedb.disk;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.bluedb.disk.config.ConfigurationService;
 import org.bluedb.disk.encryption.EncryptionService;
 import org.bluedb.disk.encryption.EncryptionUtils;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 public class BlueDbOnDiskBuilderTest {
+	
+	private Path tempDir;
+
+	@Before
+	public void before() throws IOException {
+		tempDir = Files.createTempDirectory("BlueDbOnDiskBuilderTest");
+		tempDir.toFile().deleteOnExit();
+	}
+	
+	@After
+	public void after() throws IOException {
+		tempDir.toFile().delete();
+	}
 
 	@Test
 	public void test_withEncryptionService_validEncryptionService_succeeds() {
@@ -68,6 +92,39 @@ public class BlueDbOnDiskBuilderTest {
 			// Assert
 			assertEquals(expected, ex.getMessage());
 		}
+	}
+	
+	@Test
+	public void test_withConfigurationService_nullThrowsException() {
+		try {
+			new BlueDbOnDiskBuilder()
+				.withPath(tempDir.resolve("test-collection"))
+				.withConfigurationService(null)
+				.build();
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException ex) {
+			//Expected
+		}
+	}
+	
+	@Test
+	public void test_withConfigurationService_setterWorks() {
+		ConfigurationService mockedConfigurationService = Mockito.mock(ConfigurationService.class);
+		Mockito.doReturn(false).when(mockedConfigurationService).shouldValidateObjects();
+		
+		ReadWriteDbOnDisk db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder()
+			.withPath(tempDir.resolve("test-collection"))
+			.withConfigurationService(mockedConfigurationService)
+			.build();
+		
+		assertFalse(db.getConfigurationService().shouldValidateObjects());
+		
+		Mockito.doReturn(true).when(mockedConfigurationService).shouldValidateObjects();
+		db = (ReadWriteDbOnDisk) new BlueDbOnDiskBuilder()
+				.withPath(tempDir.resolve("test-collection"))
+				.withConfigurationService(mockedConfigurationService)
+				.build();
+		assertTrue(db.getConfigurationService().shouldValidateObjects());
 	}
 
 }

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadOnlyDbOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/ReadOnlyDbOnDiskTest.java
@@ -25,6 +25,7 @@ import org.bluedb.api.keys.StringKey;
 import org.bluedb.api.keys.TimeKey;
 import org.bluedb.disk.collection.ReadOnlyCollectionOnDisk;
 import org.bluedb.disk.collection.ReadWriteTimeCollectionOnDisk;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.collection.index.TestMultiRetrievalKeyExtractor;
 import org.bluedb.disk.collection.index.TestRetrievalKeyExtractor;
 import org.bluedb.disk.file.FileUtils;
@@ -65,7 +66,7 @@ public class ReadOnlyDbOnDiskTest extends BlueDbDiskTestBase {
 		// add a recoverable
 		TimeKey key2 = new TimeKey(2L, 2L);
 		TestValue valueBob = createValue("Bob");
-		BlueSerializer serializer = new ThreadLocalFstSerializer(new Class[] {});
+		BlueSerializer serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), new Class[] {});
 		PendingChange<TestValue> change = PendingChange.createInsert(key2, valueBob, serializer);
 		readWriteCollection.getRecoveryManager().saveNewChange(change);
 		newDigest = hashDirectory(readWriteCollection.getPath());

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/ReadWriteCollectionOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/ReadWriteCollectionOnDiskTest.java
@@ -210,6 +210,8 @@ public class ReadWriteCollectionOnDiskTest extends BlueDbDiskTestBase {
 
 	@Test
 	public void test_insert_invalid() throws BlueDbException, URISyntaxException, IOException {
+		turnOnObjectValidation();
+		
 		BlueEntity<Call> invalidCall = TestUtils.loadCorruptCall();
 		
 		try {

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/ReadWriteTimeCollectionOnDiskTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/ReadWriteTimeCollectionOnDiskTest.java
@@ -30,9 +30,9 @@ import org.bluedb.api.keys.StringKey;
 import org.bluedb.api.keys.TimeFrameKey;
 import org.bluedb.api.keys.TimeKey;
 import org.bluedb.disk.BlueDbDiskTestBase;
-import org.bluedb.disk.ReadWriteDbOnDisk;
 import org.bluedb.disk.BlueDbOnDiskBuilder;
 import org.bluedb.disk.Blutils;
+import org.bluedb.disk.ReadWriteDbOnDisk;
 import org.bluedb.disk.TestValue;
 import org.bluedb.disk.collection.index.ReadableIndexOnDisk;
 import org.bluedb.disk.collection.index.TestRetrievalKeyExtractor;
@@ -333,6 +333,8 @@ public class ReadWriteTimeCollectionOnDiskTest extends BlueDbDiskTestBase {
 
 	@Test
 	public void test_insert_invalid() throws BlueDbException, URISyntaxException, IOException {
+		turnOnObjectValidation();
+		
 		BlueEntity<Call> invalidCall = TestUtils.loadCorruptCall();
 		
 		try {

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/config/TestDefaultConfigurationService.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/config/TestDefaultConfigurationService.java
@@ -1,0 +1,15 @@
+package org.bluedb.disk.collection.config;
+
+import org.bluedb.disk.config.ConfigurationService;
+
+/**
+ * Most tests should use this so that there can't be any serialization errors in order for the tests to pass.
+ */
+public class TestDefaultConfigurationService implements ConfigurationService {
+
+	@Override
+	public boolean shouldValidateObjects() {
+		return false;
+	}
+
+}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/config/TestValidationConfigurationService.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/config/TestValidationConfigurationService.java
@@ -1,0 +1,15 @@
+package org.bluedb.disk.collection.config;
+
+import org.bluedb.disk.config.ConfigurationService;
+
+/**
+ * Used by tests that want object validation turned on
+ */
+public class TestValidationConfigurationService implements ConfigurationService {
+
+	@Override
+	public boolean shouldValidateObjects() {
+		return true;
+	}
+
+}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/metadata/ReadWriteCollectionMetaDataTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/collection/metadata/ReadWriteCollectionMetaDataTest.java
@@ -19,6 +19,7 @@ import org.bluedb.disk.BlueDbDiskTestBase;
 import org.bluedb.disk.TestValue;
 import org.bluedb.disk.TestValue2;
 import org.bluedb.disk.TestValueSub;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.file.ReadWriteFileManager;
 import org.bluedb.disk.segment.SegmentSizeSetting;
@@ -79,7 +80,7 @@ public class ReadWriteCollectionMetaDataTest extends BlueDbDiskTestBase {
 	public void test_getSerializedClassList_throwsClassCastException_wrapsWithBlueDbException() throws Exception {
 		// Arrange
 		ClassCastException expected = new ClassCastException("I'm broken!");
-		ReadableCollectionMetadata metadata = new ReadWriteCollectionMetaData(targetFilePath, new EncryptionServiceWrapper(null));
+		ReadableCollectionMetadata metadata = new ReadWriteCollectionMetaData(targetFilePath, new TestDefaultConfigurationService(), new EncryptionServiceWrapper(null));
 		ReadableCollectionMetadata metadataSpy = Mockito.spy(metadata);
 		Mockito.doThrow(expected).when(metadataSpy).getFileManager();
 		// Act
@@ -195,6 +196,6 @@ public class ReadWriteCollectionMetaDataTest extends BlueDbDiskTestBase {
 
 	private ReadWriteCollectionMetaData createNewMetaData() {
 		Path tempPath = createTempFolder().toPath();
-		return new ReadWriteCollectionMetaData(tempPath, new EncryptionServiceWrapper(null));
+		return new ReadWriteCollectionMetaData(tempPath, new TestDefaultConfigurationService(), new EncryptionServiceWrapper(null));
 	}
 }

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/config/ConfigurationServiceWrapperTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/config/ConfigurationServiceWrapperTest.java
@@ -1,0 +1,55 @@
+package org.bluedb.disk.config;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.bluedb.disk.time.TimeService;
+import org.junit.Test;
+
+public class ConfigurationServiceWrapperTest {
+
+	@Test
+	public void test() {
+		final long start = System.currentTimeMillis();
+		final long half_minute = 30_000;
+		final long one_minute = 60_000;
+		
+		ConfigurationService mockedConfigurationService = mock(ConfigurationService.class);
+		doReturn(false).when(mockedConfigurationService).shouldValidateObjects();
+		
+		TimeService mockedTimeService = mock(TimeService.class);
+		doReturn(start).when(mockedTimeService).getCurrentTime();
+		
+		ConfigurationService wrapperService = new ConfigurationServiceWrapper(mockedConfigurationService, mockedTimeService, one_minute);
+
+		//If the service starts returning true and we haven't checked it yet then the first call should return true.
+		doReturn(true).when(mockedConfigurationService).shouldValidateObjects();
+		assertTrue(wrapperService.shouldValidateObjects());
+		verify(mockedConfigurationService, times(1)).shouldValidateObjects();
+
+		//The service can start returning false, but it won't check again until one minute has passed.
+		doReturn(false).when(mockedConfigurationService).shouldValidateObjects();
+		assertTrue(wrapperService.shouldValidateObjects());
+		verify(mockedConfigurationService, times(1)).shouldValidateObjects();
+		
+		//Adding half a minute won't change anything. It'll still return true and won't call the method again
+		doReturn(start + half_minute).when(mockedTimeService).getCurrentTime();
+		assertTrue(wrapperService.shouldValidateObjects());
+		verify(mockedConfigurationService, times(1)).shouldValidateObjects();
+		
+		//Setting the time to one minute after stop should result in checking again and noticing that its now false
+		doReturn(start + one_minute).when(mockedTimeService).getCurrentTime();
+		assertFalse(wrapperService.shouldValidateObjects());
+		verify(mockedConfigurationService, times(2)).shouldValidateObjects();
+
+		//Advancing 5 minutes and setting it back to true should result in another check and returning true
+		doReturn(true).when(mockedConfigurationService).shouldValidateObjects();
+		doReturn(start + (one_minute * 5)).when(mockedTimeService).getCurrentTime();
+		assertTrue(wrapperService.shouldValidateObjects());
+		verify(mockedConfigurationService, times(3)).shouldValidateObjects();
+	}
+
+}

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/BlueObjectInputTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/BlueObjectInputTest.java
@@ -19,6 +19,8 @@ import org.bluedb.TestUtils;
 import org.bluedb.api.exceptions.BlueDbException;
 import org.bluedb.disk.Blutils;
 import org.bluedb.disk.TestValue;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
+import org.bluedb.disk.collection.config.TestValidationConfigurationService;
 import org.bluedb.disk.lock.BlueReadLock;
 import org.bluedb.disk.lock.BlueWriteLock;
 import org.bluedb.disk.lock.LockManager;
@@ -42,7 +44,7 @@ public class BlueObjectInputTest extends TestCase {
 		testingFolderPath = Files.createTempDirectory(this.getClass().getSimpleName());
 		targetFilePath = Paths.get(testingFolderPath.toString(), "BlueObjectOutputStreamTest.test_junk");
 		tempFilePath = FileUtils.createTempFilePath(targetFilePath);
-		serializer = new ThreadLocalFstSerializer(new Class[]{});
+		serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), new Class[]{});
 		encryptionService = new EncryptionServiceWrapper(null);
 		fileManager = new ReadWriteFileManager(serializer, encryptionService);
 		lockManager = fileManager.getLockManager();
@@ -252,7 +254,7 @@ public class BlueObjectInputTest extends TestCase {
 
 	@Test
 	public void test_nextValidObjectFromFile_invalid() throws Exception {
-		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(new TestValidationConfigurationService(), Call.getClassesToRegister());
 		
 		Path garbagePath = TestUtils.getResourcePath("good-bad-good-stream.bin");
 		BlueReadLock<Path> readLock = lockManager.acquireReadLock(garbagePath);

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/BlueObjectOutputTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/BlueObjectOutputTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mockito;
 import org.bluedb.api.exceptions.BlueDbException;
 import org.bluedb.disk.Blutils;
 import org.bluedb.disk.TestValue;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.lock.BlueReadLock;
 import org.bluedb.disk.lock.BlueWriteLock;
 import org.bluedb.disk.lock.LockManager;
@@ -41,7 +42,7 @@ public class BlueObjectOutputTest extends TestCase {
 		testingFolderPath = Files.createTempDirectory(this.getClass().getSimpleName());
 		targetFilePath = Paths.get(testingFolderPath.toString(), "BlueObjectOutputStreamTest.test_junk");
 		tempFilePath = FileUtils.createTempFilePath(targetFilePath);
-		serializer = new ThreadLocalFstSerializer(new Class[] {});
+		serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), new Class[] {});
 		encryptionService = new EncryptionServiceWrapper(null);
 		fileManager = new ReadWriteFileManager(serializer, encryptionService);
 		lockManager = fileManager.getLockManager();

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/BlueObjectStreamSorterTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/BlueObjectStreamSorterTest.java
@@ -16,6 +16,7 @@ import org.bluedb.api.keys.BlueKey;
 import org.bluedb.api.keys.TimeKey;
 import org.bluedb.disk.Blutils;
 import org.bluedb.disk.TestValue;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.file.BlueObjectStreamSorter.BlueObjectStreamSorterConfig;
 import org.bluedb.disk.metadata.BlueFileMetadataKey;
@@ -44,7 +45,7 @@ public class BlueObjectStreamSorterTest {
 		tmpDir.toFile().deleteOnExit();
 		tmpPath = tmpDir.resolve("results");
 		
-		serializer = new ThreadLocalFstSerializer();
+		serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService());
 		encryptionService = new EncryptionServiceWrapper(null);
 		fileManager = new ReadWriteFileManager(serializer, encryptionService);
 		

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/FileUtilsTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/FileUtilsTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.bluedb.api.exceptions.BlueDbException;
 import org.bluedb.disk.Blutils;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.lock.BlueWriteLock;
 import org.bluedb.disk.lock.LockManager;
@@ -29,7 +30,7 @@ public class FileUtilsTest extends TestCase {
 
 	@Override
 	protected void setUp() throws Exception {
-		BlueSerializer serializer = new ThreadLocalFstSerializer(new Class[] {});
+		BlueSerializer serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), new Class[] {});
 		EncryptionServiceWrapper encryptionService = new EncryptionServiceWrapper(null);
 		ReadWriteFileManager fileManager = new ReadWriteFileManager(serializer, encryptionService);
 		lockManager = fileManager.getLockManager();

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/ReadFileManagerTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/ReadFileManagerTest.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.bluedb.disk.TestValue;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.metadata.BlueFileMetadata;
 import org.bluedb.disk.serialization.BlueSerializer;
@@ -18,7 +19,7 @@ public class ReadFileManagerTest {
 	public void test_readMetadata_objectSuccessfullyParsesIntoUnexpectedType_returnsNullAndResetsInputStream() throws Exception {
 		// Arrange
 		Path testPath = Paths.get(".", "test_" + this.getClass().getSimpleName());
-		BlueSerializer serializer = new ThreadLocalFstSerializer();
+		BlueSerializer serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService());
 		TestValue value = new TestValue("Sandra Bowl of Grits");
 		byte[] valueBytes = serializer.serializeObjectToByteArray(value);
 		try (DataOutputStream outputStream = FileUtils.openDataOutputStream(testPath.toFile())) {

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/ReadWriteFileManagerTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/file/ReadWriteFileManagerTest.java
@@ -21,11 +21,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.bluedb.api.exceptions.BlueDbException;
 import org.bluedb.disk.Blutils;
 import org.bluedb.disk.TestValue;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.lock.BlueReadLock;
 import org.bluedb.disk.lock.BlueWriteLock;
 import org.bluedb.disk.lock.LockManager;
-import org.bluedb.disk.metadata.BlueFileMetadata;
 import org.bluedb.disk.serialization.BlueSerializer;
 import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
 import org.bluedb.disk.serialization.validation.SerializationException;
@@ -44,7 +44,7 @@ public class ReadWriteFileManagerTest extends TestCase {
 
 	@Override
 	protected void setUp() throws Exception {
-		serializer = new ThreadLocalFstSerializer(new Class[] {});
+		serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), new Class[] {});
 		encryptionService = new EncryptionServiceWrapper(null);
 		fileManager = new ReadWriteFileManager(serializer, encryptionService);
 		lockManager = fileManager.getLockManager();

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/performance/PerformanceTests.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/performance/PerformanceTests.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.bluedb.disk.TestValue;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.serialization.BlueSerializer;
 import org.bluedb.disk.serialization.ThreadLocalFstSerializer;
 import org.bluedb.disk.serialization.validation.SerializationException;
@@ -41,10 +42,10 @@ public class PerformanceTests {
 		file = tempDir.resolve("test.bin");
 
 		if(registerClass) {
-			serializer = new ThreadLocalFstSerializer(TestValue.class);
+			serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), TestValue.class);
 		}
 		else {
-			serializer = new ThreadLocalFstSerializer();
+			serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService());
 		}
 		
 		Random r = new Random();

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/recovery/OnDiskSortedChangeSupplierTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/recovery/OnDiskSortedChangeSupplierTest.java
@@ -10,6 +10,7 @@ import java.util.Comparator;
 
 import org.bluedb.disk.Blutils;
 import org.bluedb.disk.TestValue;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.encryption.EncryptionService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.file.BlueObjectOutput;
@@ -38,7 +39,7 @@ public class OnDiskSortedChangeSupplierTest extends SortedChangeSupplierTest {
 		
 		supplierFilePath = tmpDir.resolve("supplier.bin");
 		
-		serializer = new ThreadLocalFstSerializer();
+		serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService());
 		
 		encryptionService = Mockito.mock(EncryptionService.class);
 		when(encryptionService.isEncryptionEnabled()).thenReturn(false);

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/recovery/RecoveryManagerTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/recovery/RecoveryManagerTest.java
@@ -20,6 +20,7 @@ import org.bluedb.api.keys.TimeKey;
 import org.bluedb.disk.BlueDbDiskTestBase;
 import org.bluedb.disk.StreamUtils;
 import org.bluedb.disk.TestValue;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.file.FileUtils;
 import org.bluedb.disk.query.QueryOnDisk;
 import org.bluedb.disk.serialization.BlueEntity;
@@ -35,14 +36,14 @@ public class RecoveryManagerTest extends BlueDbDiskTestBase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		serializer = new ThreadLocalFstSerializer(new Class[] {});
+		serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), new Class[] {});
 	}
 
 	@Test
 	public void test_getPendingFileName() throws Exception {
 		BlueKey key = createKey(1, 2);
 		TestValue value = createValue("Joe");
-		BlueSerializer serializer = new ThreadLocalFstSerializer(new Class[] {});
+		BlueSerializer serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), new Class[] {});
 		PendingChange<TestValue> change = PendingChange.createInsert(key, value, serializer);
 		String fileName1 = RecoveryManager.getPendingFileName(change);
 
@@ -57,7 +58,7 @@ public class RecoveryManagerTest extends BlueDbDiskTestBase {
 	public void test_getCompletedFileName() throws Exception {
 		BlueKey key = createKey(1, 2);
 		TestValue value = createValue("Joe");
-		BlueSerializer serializer = new ThreadLocalFstSerializer(new Class[] {});
+		BlueSerializer serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), new Class[] {});
 		PendingChange<TestValue> change = PendingChange.createInsert(key, value, serializer);
 		String pendingFileName = RecoveryManager.getPendingFileName(change);
 		String completedFileName = RecoveryManager.getCompletedFileName(change);

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/segment/SegmentSizeSettingsTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/segment/SegmentSizeSettingsTest.java
@@ -39,6 +39,7 @@ import org.bluedb.api.keys.StringKey;
 import org.bluedb.api.keys.TimeFrameKey;
 import org.bluedb.api.keys.TimeKey;
 import org.bluedb.api.keys.UUIDKey;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.file.FileUtils;
 import org.bluedb.disk.segment.path.SegmentSizeConfiguration;
 import org.bluedb.disk.serialization.BlueSerializer;
@@ -205,7 +206,7 @@ public class SegmentSizeSettingsTest {
 	@Test
 	public void testDeserialization() throws URISyntaxException, IOException, SerializationException {
 		Path serializedSettingsPath = TestUtils.getResourcePath("segment_size_settings.bin");
-		BlueSerializer serializer = new ThreadLocalFstSerializer();
+		BlueSerializer serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService());
 		
 		List<SegmentSizeSetting> allValuesInCodeInAlphabeticalOrder = Arrays.asList(SegmentSizeSetting.values());
 		Collections.sort(allValuesInCodeInAlphabeticalOrder, Comparator.comparing(SegmentSizeSetting::name));

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/segment/path/SegmentPathManagerTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/segment/path/SegmentPathManagerTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.bluedb.disk.Blutils;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
 import org.bluedb.disk.encryption.EncryptionServiceWrapper;
 import org.bluedb.disk.file.ReadOnlyFileManager;
 import org.bluedb.disk.segment.Range;
@@ -53,6 +54,7 @@ public class SegmentPathManagerTest {
 		System.out.println("Total path: " + segmentPath);
 	}
 	
+	@SuppressWarnings("unused")
 	private static void findAndPrintTargetSegmentInformation(SegmentSizeSetting segmentSizeSetting) {
 		System.out.println("Segment Size: " + segmentSizeSetting);
 		Range targetRange = new Range(4096786432l, 4097835007l);
@@ -65,7 +67,7 @@ public class SegmentPathManagerTest {
 	}
 	
 	private static List<ReadOnlySegment<Serializable>> findTargetSegments(SegmentSizeSetting segmentSizeSetting, SegmentPathManager pathManager, Range targetRange) {
-		BlueSerializer serializer = new ThreadLocalFstSerializer(new Class[] {});
+		BlueSerializer serializer = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), new Class[] {});
 		EncryptionServiceWrapper encryptionService = new EncryptionServiceWrapper(null);
 		ReadOnlyFileManager fileManager = new ReadOnlyFileManager(serializer, encryptionService);
 		

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/serialization/ThreadLocalFstSerializerTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/serialization/ThreadLocalFstSerializerTest.java
@@ -16,6 +16,8 @@ import org.bluedb.api.exceptions.BlueDbException;
 import org.bluedb.api.keys.TimeFrameKey;
 import org.bluedb.disk.TestValue;
 import org.bluedb.disk.TestValue2;
+import org.bluedb.disk.collection.config.TestDefaultConfigurationService;
+import org.bluedb.disk.collection.config.TestValidationConfigurationService;
 import org.bluedb.disk.models.calls.Call;
 import org.bluedb.disk.models.calls.CallEvent;
 import org.bluedb.disk.models.calls.CallRecording;
@@ -36,12 +38,12 @@ public class ThreadLocalFstSerializerTest {
 		 * use FST a little bit. This test keeps someone from changing it back to the other way
 		 * since that way has an issue.
 		 */
-		ThreadLocalFstSerializer s1 = new ThreadLocalFstSerializer(TestValue.class);
+		ThreadLocalFstSerializer s1 = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), TestValue.class);
 		TestValue value1 = new TestValue("Derek", 1);
 		TestValue clone1 = s1.clone(value1);
 		assertEquals(value1, clone1);
 		
-		ThreadLocalFstSerializer s2 = new ThreadLocalFstSerializer(TestValue2.class);
+		ThreadLocalFstSerializer s2 = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), TestValue2.class);
 		TestValue value2 = new TestValue("Derek2", 2);
 		TestValue clone2 = s2.clone(value2);
 		assertEquals(value2, clone2);
@@ -53,8 +55,8 @@ public class ThreadLocalFstSerializerTest {
 	
 	@Test
 	public void testAddingRegisteredClass() throws SerializationException {
-		ThreadLocalFstSerializer s1 = new ThreadLocalFstSerializer();
-		ThreadLocalFstSerializer s2 = new ThreadLocalFstSerializer(TestValue.class);
+		ThreadLocalFstSerializer s1 = new ThreadLocalFstSerializer(new TestDefaultConfigurationService());
+		ThreadLocalFstSerializer s2 = new ThreadLocalFstSerializer(new TestDefaultConfigurationService(), TestValue.class);
 		
 		TestValue originalValue = new TestValue("Derek", 3);
 		byte[] bytes = s1.serializeObjectToByteArray(originalValue);
@@ -65,7 +67,7 @@ public class ThreadLocalFstSerializerTest {
 	
 	@Test
 	public void testSerializingInvalidObject() throws URISyntaxException, BlueDbException, IOException {
-		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(new TestValidationConfigurationService(), Call.getClassesToRegister());
 		Object invalidObject = TestUtils.loadCorruptCall();
 		
 		try {
@@ -102,7 +104,7 @@ public class ThreadLocalFstSerializerTest {
 		int callCountPerTest = 100;
 		Random random = new Random();
 		
-		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(new TestValidationConfigurationService(), Call.getClassesToRegister());
 		
 		for(int i = 0; i < testCount; i++) {
 			try {

--- a/BlueDBOnDisk/src/test/java/org/bluedb/disk/serialization/validation/ObjectValidationTest.java
+++ b/BlueDBOnDisk/src/test/java/org/bluedb/disk/serialization/validation/ObjectValidationTest.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 
 import org.bluedb.TestUtils;
 import org.bluedb.disk.TestValue;
+import org.bluedb.disk.collection.config.TestValidationConfigurationService;
 import org.bluedb.disk.models.Blob;
 import org.bluedb.disk.models.calls.Call;
 import org.bluedb.disk.models.calls.CallV2;
@@ -29,6 +30,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ObjectValidationTest {
+	
+	@Test
+	public void testNull_doesNotThrowException() throws SerializationException {
+		ObjectValidation.validateFieldValueTypesForObject(null);
+	}
 
 	@Test
 	public void testValidateFieldValueTypesForValidObjects() {
@@ -102,7 +108,7 @@ public class ObjectValidationTest {
 		
 		try {
 			//Ensure that cycles are caught after serializing and deserializing an object that has a cycle
-			ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer();
+			ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(new TestValidationConfigurationService());
 			byte[] bytes = serializer.serializeObjectToByteArray(basicValidObjectWithBoxedValuesSwappedAndCollectionsSet);
 			TypeValidationTestObject serializedClone = (TypeValidationTestObject) serializer.deserializeObjectFromByteArray(bytes);
 			assertEquals(basicValidObjectWithBoxedValuesSwappedAndCollectionsSet, serializedClone);
@@ -186,13 +192,13 @@ public class ObjectValidationTest {
 
 	@Test
 	public void testCorruptCall() throws SerializationException, IllegalArgumentException, IllegalAccessException, IOException, URISyntaxException {
-		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(new TestValidationConfigurationService(), Call.getClassesToRegister());
 		testCorruptObject(serializer, "corruptCall-1.bin");
 	}
 
 	@Test
 	public void testCorruptCallInArray() throws SerializationException, IllegalArgumentException, IllegalAccessException, IOException, URISyntaxException {
-		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(Call.getClassesToRegister());
+		ThreadLocalFstSerializer serializer = new ThreadLocalFstSerializer(new TestValidationConfigurationService(), Call.getClassesToRegister());
 		testCorruptObject(serializer, "corruptCallArrayList-1.bin");
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ subprojects {
     
     repositories {
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
     
     sourceCompatibility = 1.8


### PR DESCRIPTION
- Updated to depend on new version of forked FST which shouldn't cause 
invalid objects on deserialization anymore.
- Added a configuration service that can be supplied to BlueDB when it
is created. BlueDB can then use it to check periodically if it should be
validating objects. In the future it could be used for other
configuration as well. This allows a BlueDB user to specify whether or
not resources should be expended validating objects serialized or
deserialized by FST/BlueDB. This saves a lot of CPU during queries but
legacy data or further unknown FST issues could still cause issues so we
want it to still default to validate objects.